### PR TITLE
mempool: publish fee snapshot so estimates do not block accepts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
 name = "rbitcoin-net"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "bip324",
  "bitcoin",
  "rbitcoin-consensus",

--- a/crates/rbitcoin-esplora/src/handlers.rs
+++ b/crates/rbitcoin-esplora/src/handlers.rs
@@ -734,20 +734,26 @@ pub async fn mempool_info(State(st): State<AppState>) -> Response {
 
 pub async fn fee_estimates(State(st): State<AppState>) -> Response {
     let mut obj = serde_json::Map::new();
-    let targets = [1u32, 2, 3, 4, 5, 6, 10, 20, 144, 504, 1008];
-    for t in targets {
-        let btc_kb = st
-            .mempool
-            .as_ref()
-            .map(|m| m.estimate_fee_btc_per_kb(t))
-            .unwrap_or(-1.0);
-        let sat_vb = if btc_kb < 0.0 {
-            1.0 // floor when empty
-        } else {
-            // BTC/kB → sat/vB: * 1e8 / 1000
-            btc_kb * 100_000.0
-        };
-        obj.insert(t.to_string(), json!(sat_vb));
+    // One snapshot refresh + Arc load (not 11× independent graph walks).
+    let pairs: Vec<(u32, f64)> = st
+        .mempool
+        .as_ref()
+        .map(|m| m.fee_estimates_btc_per_kb())
+        .unwrap_or_default();
+    if pairs.is_empty() {
+        for t in [1u32, 2, 3, 4, 5, 6, 10, 20, 144, 504, 1008] {
+            obj.insert(t.to_string(), json!(1.0));
+        }
+    } else {
+        for (t, btc_kb) in pairs {
+            let sat_vb = if btc_kb < 0.0 {
+                1.0 // floor when empty
+            } else {
+                // BTC/kB → sat/vB: * 1e8 / 1000
+                btc_kb * 100_000.0
+            };
+            obj.insert(t.to_string(), json!(sat_vb));
+        }
     }
     Json(Value::Object(obj)).into_response()
 }

--- a/crates/rbitcoin-mempool/src/graph.rs
+++ b/crates/rbitcoin-mempool/src/graph.rs
@@ -54,6 +54,34 @@ impl Chunk {
     }
 }
 
+/// Frontier feerate from a **best-first** chunk list (no graph walk).
+///
+/// Used by fee snapshot refresh so multi-target estimates share one linearize.
+pub fn frontier_feerate_from_chunks(chunks: &[Chunk], target_wu: u64) -> Option<u64> {
+    if chunks.is_empty() {
+        return None;
+    }
+    let mut cum = 0u64;
+    let mut last_rate = chunks[0].fee_rate_sat_per_kvb();
+    for ch in chunks {
+        last_rate = ch.fee_rate_sat_per_kvb();
+        cum = cum.saturating_add(ch.weight);
+        if cum >= target_wu {
+            return Some(last_rate.max(1));
+        }
+    }
+    Some(last_rate.max(1))
+}
+
+/// Weight strictly above `rate_sat_per_kvb` from a best-first chunk list.
+pub fn weight_above_from_chunks(chunks: &[Chunk], rate_sat_per_kvb: u64) -> u64 {
+    chunks
+        .iter()
+        .filter(|c| c.fee_rate_sat_per_kvb() > rate_sat_per_kvb)
+        .map(|c| c.weight)
+        .sum()
+}
+
 /// Cluster identity: sorted member set fingerprint (min txid as representative).
 #[derive(Debug, Clone)]
 pub struct Cluster {
@@ -417,29 +445,12 @@ impl TxGraph {
     /// If total pool weight is below `target_wu`, returns the **lowest** chunk
     /// rate present (still need min-relay floor at the hub).
     pub fn frontier_feerate_sat_per_kvb(&self, target_wu: u64) -> Option<u64> {
-        let chunks = self.mining_chunks_best_first();
-        if chunks.is_empty() {
-            return None;
-        }
-        let mut cum = 0u64;
-        let mut last_rate = chunks[0].fee_rate_sat_per_kvb();
-        for ch in &chunks {
-            last_rate = ch.fee_rate_sat_per_kvb();
-            cum = cum.saturating_add(ch.weight);
-            if cum >= target_wu {
-                return Some(last_rate.max(1));
-            }
-        }
-        Some(last_rate.max(1))
+        frontier_feerate_from_chunks(&self.mining_chunks_best_first(), target_wu)
     }
 
     /// Weight (WU) of chunks with feerate strictly greater than `rate_sat_per_kvb`.
     pub fn weight_above_feerate(&self, rate_sat_per_kvb: u64) -> u64 {
-        self.mining_chunks_best_first()
-            .into_iter()
-            .filter(|c| c.fee_rate_sat_per_kvb() > rate_sat_per_kvb)
-            .map(|c| c.weight)
-            .sum()
+        weight_above_from_chunks(&self.mining_chunks_best_first(), rate_sat_per_kvb)
     }
 
     /// Lowest fee-rate chunk across all clusters (for P5 eviction). `None` if empty.
@@ -585,6 +596,13 @@ mod tests {
         let r_deep = g.frontier_feerate_sat_per_kvb(wa + wb).unwrap();
         assert!(r_hi >= r_deep);
         assert!(g.weight_above_feerate(0) >= wa);
+        // Shared-slice helpers match full-graph methods (fee snapshot path).
+        let ch = g.mining_chunks_best_first();
+        assert_eq!(
+            frontier_feerate_from_chunks(&ch, 1),
+            g.frontier_feerate_sat_per_kvb(1)
+        );
+        assert_eq!(weight_above_from_chunks(&ch, 0), g.weight_above_feerate(0));
     }
 
     fn spend_op(seed: [u8; 32], _inv: u64, outv: u64) -> Transaction {

--- a/crates/rbitcoin-mempool/src/lib.rs
+++ b/crates/rbitcoin-mempool/src/lib.rs
@@ -47,7 +47,8 @@ pub use fee_flow::{
     FeeFlowMeter, ADMIT_HALF_LIFE_SECS, CONFIRM_HALF_LIFE_SECS, WARM_AFTER_ADMITS, WARM_AFTER_SECS,
 };
 pub use graph::{
-    Chunk, Cluster, TxEntry, TxGraph, MAX_CLUSTER_COUNT, MAX_CLUSTER_VSIZE, MAX_CLUSTER_WEIGHT,
+    frontier_feerate_from_chunks, weight_above_from_chunks, Chunk, Cluster, TxEntry, TxGraph,
+    MAX_CLUSTER_COUNT, MAX_CLUSTER_VSIZE, MAX_CLUSTER_WEIGHT,
 };
 pub use orphanage::{
     Orphanage, DEFAULT_ORPHAN_MAX_COUNT, DEFAULT_ORPHAN_MAX_WEIGHT, MAX_ORPHAN_TX_WEIGHT,

--- a/crates/rbitcoin-net/Cargo.toml
+++ b/crates/rbitcoin-net/Cargo.toml
@@ -17,6 +17,7 @@ rbitcoin-mempool = { workspace = true }
 bitcoin = { workspace = true }
 bip324 = { workspace = true }
 tokio = { workspace = true }
+arc-swap = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rbitcoin-net/src/tx_relay.rs
+++ b/crates/rbitcoin-net/src/tx_relay.rs
@@ -5,20 +5,54 @@
 //! accept stays on [`rbitcoin_mempool::ActiveMempool::accept_package`]. Unknown
 //! `sendpackages` / package commands are ignored until a bitcoin crate upgrade.
 
+use arc_swap::ArcSwap;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::Hash;
 use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid, Wtxid};
 use rbitcoin_mempool::{
-    default_candidate_rates, min_rate_for_capacity, AcceptError, AcceptResult, ActiveMempool,
-    ChainTipCtx, Coin, FeeFlowMeter, UtxoProvider,
+    default_candidate_rates, frontier_feerate_from_chunks, min_rate_for_capacity,
+    weight_above_from_chunks, AcceptError, AcceptResult, ActiveMempool, ChainTipCtx, Coin,
+    FeeFlowMeter, UtxoProvider, BLOCK_WEIGHT_WU,
 };
 use rbitcoin_query::Query;
 use rbitcoin_store::OutputRecord;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
+
+/// Max age of a published fee snapshot before refresh (request path is still Arc-load only
+/// after a concurrent refresh has finished; see [`MempoolHub::maybe_refresh_fee_snapshot`]).
+const FEE_SNAPSHOT_MAX_AGE: Duration = Duration::from_secs(1);
+
+/// Esplora `/fee-estimates` keys + common Electrum depths (after 0–2 → default map).
+const FEE_SNAPSHOT_DEPTHS: &[u32] = &[1, 2, 3, 4, 5, 6, 10, 20, 144, 504, 1008];
+
+/// Immutable published fee table (request path never walks the live graph).
+#[derive(Clone, Debug)]
+struct FeeSnapshot {
+    /// BTC/kB by confirm-target depth (post 0–2 mapping). Missing → treat empty.
+    by_depth_btc_per_kb: HashMap<u32, f64>,
+    computed_at: Instant,
+}
+
+impl FeeSnapshot {
+    fn empty(now: Instant) -> Self {
+        Self {
+            by_depth_btc_per_kb: HashMap::new(),
+            computed_at: now,
+        }
+    }
+
+    fn rate_btc_per_kb(&self, depth: u32) -> f64 {
+        self.by_depth_btc_per_kb
+            .get(&depth)
+            .copied()
+            .unwrap_or(-1.0)
+    }
+}
 
 /// Resolve prevouts from the relational archive (confirmed **unspent** UTXOs).
 ///
@@ -137,6 +171,10 @@ pub struct MempoolHub {
     confirm_feerate_memory: Mutex<std::collections::VecDeque<u64>>,
     /// Process-local admit/confirm/evict EMA for flow-aware fee estimates.
     fee_flow: Mutex<FeeFlowMeter>,
+    /// Published fee table for Electrum/Esplora (refreshed dirty ∥ max-age, singleflight).
+    fee_snapshot: ArcSwap<FeeSnapshot>,
+    fee_dirty: AtomicBool,
+    fee_refreshing: AtomicBool,
     // Tip-follow 5s DEBUG meters (sample-and-reset).
     meter_accepts: AtomicU64,
     meter_rejects: AtomicU64,
@@ -175,6 +213,9 @@ impl MempoolHub {
             )),
             confirm_feerate_memory: Mutex::new(std::collections::VecDeque::with_capacity(64)),
             fee_flow: Mutex::new(FeeFlowMeter::new(Instant::now())),
+            fee_snapshot: ArcSwap::from_pointee(FeeSnapshot::empty(Instant::now())),
+            fee_dirty: AtomicBool::new(true),
+            fee_refreshing: AtomicBool::new(false),
             meter_accepts: AtomicU64::new(0),
             meter_rejects: AtomicU64::new(0),
             meter_accept_us: AtomicU64::new(0),
@@ -344,6 +385,7 @@ impl MempoolHub {
         }
         if n > 0 {
             let _ = g.maybe_compact();
+            self.mark_fee_dirty();
         }
         n
     }
@@ -510,6 +552,7 @@ impl MempoolHub {
         if let Ok(mut m) = self.fee_flow.lock() {
             m.note_admit(weight, rate, Instant::now());
         }
+        self.mark_fee_dirty();
     }
 
     fn note_fee_flow_confirm(&self, weight: u64, fee_sat: u64) {
@@ -517,6 +560,101 @@ impl MempoolHub {
         if let Ok(mut m) = self.fee_flow.lock() {
             m.note_confirm(weight, rate, Instant::now());
         }
+        self.mark_fee_dirty();
+    }
+
+    fn mark_fee_dirty(&self) {
+        self.fee_dirty.store(true, Ordering::Release);
+    }
+
+    /// Map API target blocks → engine depth (0–2 → default horizon of 1).
+    fn fee_depth(target_blocks: u32) -> u32 {
+        if target_blocks == 0 || target_blocks <= 2 {
+            Self::DEFAULT_HORIZON_BLOCKS
+        } else {
+            target_blocks
+        }
+    }
+
+    /// Lazy singleflight refresh when dirty or older than [`FEE_SNAPSHOT_MAX_AGE`].
+    fn maybe_refresh_fee_snapshot(&self) {
+        let now = Instant::now();
+        let snap = self.fee_snapshot.load_full();
+        let stale = now
+            .checked_duration_since(snap.computed_at)
+            .map(|d| d >= FEE_SNAPSHOT_MAX_AGE)
+            .unwrap_or(true);
+        let dirty = self.fee_dirty.load(Ordering::Acquire);
+        // Always refresh when never populated with real data and dirty (first admit path).
+        if !dirty && !stale {
+            return;
+        }
+        if self
+            .fee_refreshing
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            // Another thread is refreshing; callers use the previous Arc.
+            return;
+        }
+        self.refresh_fee_snapshot();
+        self.fee_refreshing.store(false, Ordering::Release);
+    }
+
+    /// One graph linearize under short read lock, then pure math off-lock → publish.
+    fn refresh_fee_snapshot(&self) {
+        let t0 = Instant::now();
+        let chunks = {
+            let g = self.inner.read().unwrap();
+            g.graph.mining_chunks_best_first()
+        };
+
+        let now = Instant::now();
+        let inflow = match self.fee_flow.lock() {
+            Ok(mut flow) if flow.is_warm(now) => Some(flow.admit_rates_wu_s(now)),
+            _ => None,
+        };
+        let candidates = default_candidate_rates();
+        let min_r = rbitcoin_consensus::policy::MIN_RELAY_FEE_RATE_SAT_PER_KVB;
+        let confirm_floor = self.confirm_memory_floor_sat_per_kvb();
+
+        let mut by_depth = HashMap::with_capacity(FEE_SNAPSHOT_DEPTHS.len());
+        for &depth in FEE_SNAPSHOT_DEPTHS {
+            let target_wu = u64::from(depth).saturating_mul(BLOCK_WEIGHT_WU);
+            let frontier = frontier_feerate_from_chunks(&chunks, target_wu);
+            let projected = inflow.as_ref().and_then(|inf| {
+                min_rate_for_capacity(
+                    |r| weight_above_from_chunks(&chunks, r),
+                    inf,
+                    depth,
+                    &candidates,
+                )
+            });
+            let mut rate = match (projected, frontier) {
+                (Some(p), Some(f)) => p.max(f),
+                (Some(p), None) => p,
+                (None, Some(f)) => f,
+                (None, None) => {
+                    // Empty pool: optional confirm-memory floor as BTC/kB.
+                    let v = confirm_floor
+                        .map(|r| (r as f64) / 100_000_000.0)
+                        .unwrap_or(-1.0);
+                    by_depth.insert(depth, v);
+                    continue;
+                }
+            };
+            rate = rate.max(min_r);
+            if let Some(floor) = confirm_floor {
+                rate = rate.max(floor);
+            }
+            by_depth.insert(depth, (rate as f64) / 100_000_000.0);
+        }
+
+        self.fee_snapshot.store(Arc::new(FeeSnapshot {
+            by_depth_btc_per_kb: by_depth,
+            computed_at: t0,
+        }));
+        self.fee_dirty.store(false, Ordering::Release);
     }
 
     fn finish_accept_err(&self, us: u64, e: AcceptError) -> Result<AcceptResult, AcceptError> {
@@ -769,50 +907,26 @@ impl MempoolHub {
     /// Standard / target-depth fee in BTC/kB (Engine v2 when flow meter warm).
     ///
     /// **Default product answer is 10-minute inclusion** (`target_blocks` 0–2 →
-    /// depth of [`Self::DEFAULT_HORIZON_BLOCKS`] blocks). When [`FeeFlowMeter`]
-    /// is warm, rate is `max(projected, frontier, confirm_memory, min_relay)`.
-    /// When cold, live inclusion frontier (v1) + floors. Empty pool → negative
-    /// (Electrum “unavailable”) unless only a confirm-memory floor exists.
+    /// depth of [`Self::DEFAULT_HORIZON_BLOCKS`] blocks).
+    ///
+    /// **Non-blocking vs accept:** returns from a **published snapshot** (Arc).
+    /// Graph linearize runs only on dirty/stale singleflight **refresh** (≤~1 s
+    /// stale; one `mining_chunks` per refresh for all depths). Request path does
+    /// not hold the hub lock across multi-pass walks.
     pub fn estimate_fee_btc_per_kb(&self, target_blocks: u32) -> f64 {
-        let depth = if target_blocks == 0 || target_blocks <= 2 {
-            Self::DEFAULT_HORIZON_BLOCKS
-        } else {
-            target_blocks
-        };
-        let target_wu = u64::from(depth).saturating_mul(Self::BLOCK_WEIGHT_WU);
-        let min_r = rbitcoin_consensus::policy::MIN_RELAY_FEE_RATE_SAT_PER_KVB;
+        self.maybe_refresh_fee_snapshot();
+        let depth = Self::fee_depth(target_blocks);
+        self.fee_snapshot.load().rate_btc_per_kb(depth)
+    }
 
-        let g = self.inner.read().unwrap();
-        let frontier = g.graph.frontier_feerate_sat_per_kvb(target_wu);
-        let now = Instant::now();
-        let projected = match self.fee_flow.lock() {
-            Ok(mut flow) if flow.is_warm(now) => {
-                let inflow = flow.admit_rates_wu_s(now);
-                let candidates = default_candidate_rates();
-                min_rate_for_capacity(
-                    |r| g.graph.weight_above_feerate(r),
-                    &inflow,
-                    depth,
-                    &candidates,
-                )
-            }
-            _ => None,
-        };
-        drop(g);
-
-        let mut rate = match (projected, frontier) {
-            (Some(p), Some(f)) => p.max(f),
-            (Some(p), None) => p,
-            (None, Some(f)) => f,
-            (None, None) => {
-                return self.confirm_memory_floor_btc_per_kb().unwrap_or(-1.0);
-            }
-        };
-        rate = rate.max(min_r);
-        if let Some(floor) = self.confirm_memory_floor_sat_per_kvb() {
-            rate = rate.max(floor);
-        }
-        (rate as f64) / 100_000_000.0
+    /// All Esplora `/fee-estimates` depths in one Arc load (+ optional refresh).
+    pub fn fee_estimates_btc_per_kb(&self) -> Vec<(u32, f64)> {
+        self.maybe_refresh_fee_snapshot();
+        let snap = self.fee_snapshot.load_full();
+        FEE_SNAPSHOT_DEPTHS
+            .iter()
+            .map(|&d| (d, snap.rate_btc_per_kb(d)))
+            .collect()
     }
 
     /// Mining-order chunk snapshot for diagnostics / future templates.
@@ -852,11 +966,6 @@ impl MempoolHub {
         let mut v: Vec<u64> = mem.iter().copied().collect();
         v.sort_unstable();
         Some(v[v.len() / 2].max(rbitcoin_consensus::policy::MIN_RELAY_FEE_RATE_SAT_PER_KVB))
-    }
-
-    fn confirm_memory_floor_btc_per_kb(&self) -> Option<f64> {
-        self.confirm_memory_floor_sat_per_kvb()
-            .map(|r| (r as f64) / 100_000_000.0)
     }
 
     fn push_confirm_memory(&self, rate_sat_per_kvb: u64) {
@@ -1488,6 +1597,7 @@ mod tests {
                 for _ in 0..32 {
                     let _ = h.live_count();
                     let _ = h.estimate_fee_btc_per_kb(2);
+                    let _ = h.fee_estimates_btc_per_kb();
                     let _ = h.fee_histogram();
                     let _ = h.list_live();
                     let _ = h.contains_wtxid(&Wtxid::from_byte_array([0u8; 32]));
@@ -1497,6 +1607,28 @@ mod tests {
         for h in handles {
             h.join().expect("reader");
         }
+        let _ = std::fs::remove_dir_all(&mp_dir);
+        let _ = std::fs::remove_dir_all(&store_dir);
+    }
+
+    /// Fee snapshot covers Esplora depths; request path uses published table.
+    #[test]
+    fn fee_snapshot_bulk_and_estimate_share_table() {
+        let store_dir = tmp();
+        let mp_dir = tmp();
+        let q = Query::open_or_create(&store_dir).unwrap();
+        let hub = MempoolHub::open(&mp_dir, Arc::new(q)).unwrap();
+        hub.set_relay_enabled(true);
+        // Empty pool: negative / unavailable for Electrum-style single target.
+        assert!(hub.estimate_fee_btc_per_kb(2) < 0.0);
+        let bulk = hub.fee_estimates_btc_per_kb();
+        assert_eq!(bulk.len(), 11);
+        assert!(bulk.iter().all(|(d, v)| *d >= 1 && *v < 0.0));
+        // Second call hits cache (not dirty/stale immediately) — still consistent.
+        assert_eq!(
+            hub.estimate_fee_btc_per_kb(6),
+            hub.fee_estimates_btc_per_kb()[4].1
+        );
         let _ = std::fs::remove_dir_all(&mp_dir);
         let _ = std::fs::remove_dir_all(&store_dir);
     }

--- a/docs/mempool-fee-estimation.md
+++ b/docs/mempool-fee-estimation.md
@@ -17,6 +17,18 @@ We intentionally do **not** present “90th percentile of live txs” as the lon
 story. The 10-minute inclusion question is clearer for wallets and is where we
 intend to stand out versus Core-style historical estimators and crude percentiles.
 
+## Non-blocking vs accept (published snapshot)
+
+Fee APIs **do not** walk the live mempool graph on every Electrum/Esplora request.
+
+| Path | Behavior |
+|------|----------|
+| Accept / remove | Marks fee cache **dirty** only (no recompute on the admit critical path). |
+| Refresh | Singleflight: at most one recompute; **one** `mining_chunks_best_first` under a short hub read lock, then pure math off-lock for all depths. |
+| Request | Loads a published `Arc` snapshot (≤ **~1 s** stale when dirty/max-age). |
+
+This avoids fee-estimates holding the hub lock for multi-second full-pool linearizes (which previously blocked accepts and vice versa). Estimates may lag a short bound after fee spikes; they still apply min-relay and confirm-memory floors on publish.
+
 ## Engine v2 (shipped)
 
 **Temporal flow projection** under the same APIs as v1:


### PR DESCRIPTION
Fee APIs previously held the hub read lock while re-running full-graph mining linearization for every target and feerate candidate (Esplora ×11 targets × many weight_above walks). At ~20k live txs that cost multi-second CPU and stalled accept writers on the same RwLock.

Publish an Arc fee table refreshed singleflight on dirty or max ~1s age: one mining_chunks under a short read lock, then pure frontier/weight_above math off-lock for all Esplora depths. Accept/remove only mark dirty. Electrum estimatefee and Esplora /fee-estimates load the snapshot only.

Also add frontier/weight_above helpers over a shared chunk slice and document freshness + non-blocking behavior.