### PR TITLE
ci: upload musl static binaries after green master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
           workspaces: ". -> target/dev"
       - name: build bins
         run: cargo build -p rbitcoin-node -p rbitcoin-cli
+      - name: stage-musl-artifacts self-test
+        run: ./scripts/stage-musl-artifacts.test.sh
       - name: cargo test
         run: cargo test --workspace
 

--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -37,12 +37,16 @@ jobs:
     name: musl
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # workflow_run is privileged (default-branch workflow + GITHUB_TOKEN).
+    # CodeQL actions/untrusted-checkout/critical requires an explicit same-repo
+    # check before checkout+run of head_sha (branch filter alone is not enough).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push' &&
-        contains(fromJSON('["master", "main"]'), github.event.workflow_run.head_branch)
+        contains(fromJSON('["master", "main"]'), github.event.workflow_run.head_branch) &&
+        github.event.workflow_run.head_repository.full_name == github.repository
       )
     env:
       # workflow_run.head_sha is the green commit. dispatch: input or tip.
@@ -52,6 +56,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.BUILD_REF }}
+          # Do not write GITHUB_TOKEN into .git — later steps run tree scripts.
+          persist-credentials: false
 
       # workflow_run's github.sha is the default-branch tip, not the green
       # commit. Name artifacts from the tree we actually built.

--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -1,0 +1,99 @@
+# Portable static musl binaries after a **green** master `ci` run.
+#
+# Not a required PR check. Failures show as the `musl` workflow only.
+# Uses `nix build .#rbitcoin-musl` (same as scripts/repro-build.sh) — never
+# host `cargo build --release`.
+#
+# Triggers:
+#   - workflow_run: `ci` succeeded on a **push** to master/main
+#   - workflow_dispatch: rebuild a ref (retry / operator request)
+#
+# Artifacts: rbitcoin-musl-x86_64-linux-<12-sha> (node, cli, SHA256SUMS).
+# First run is a cold crane deps layer; later runs restore the Nix store cache.
+
+name: musl
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or SHA to build (empty = this branch tip)
+        required: false
+        default: ""
+
+concurrency:
+  group: musl-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  build:
+    name: musl
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        contains(fromJSON('["master", "main"]'), github.event.workflow_run.head_branch)
+      )
+    env:
+      # workflow_run.head_sha is the green commit. dispatch: input or tip.
+      BUILD_REF: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
+    steps:
+      - name: Checkout green revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.BUILD_REF }}
+
+      # workflow_run's github.sha is the default-branch tip, not the green
+      # commit. Name artifacts from the tree we actually built.
+      - name: Record built SHA
+        id: meta
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "short=${sha:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            max-jobs = auto
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: musl-${{ runner.os }}-${{ hashFiles('flake.lock', 'Cargo.lock') }}
+          restore-prefixes-first-match: musl-${{ runner.os }}-
+          gc-max-store-size-linux: 8G
+          purge: true
+          purge-prefixes: musl-${{ runner.os }}-
+          purge-last-accessed: P7D
+          purge-primary-key: never
+
+      - name: Build musl (flake)
+        run: ./scripts/repro-build.sh musl ./result
+
+      - name: Stage artifacts
+        run: ./scripts/stage-musl-artifacts.sh ./result ./dist
+
+      - name: Upload musl binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rbitcoin-musl-x86_64-linux-${{ steps.meta.outputs.short }}
+          path: |
+            dist/rbitcoin-node
+            dist/rbitcoin-cli
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,12 @@ which gate failed: **`fmt`**, **`clippy`**, **`test`**, **`multinode`**, **`cove
 **Do not push or leave a commit that would fail any of them.** A red CI on
 `master` is incomplete work.
 
+Workflow [`musl.yml`](.github/workflows/musl.yml) is **not** required. After
+`ci` succeeds on a **push** to `master`/`main`, it builds
+`nix build .#rbitcoin-musl` and uploads node/cli + `SHA256SUMS`. A red `musl`
+run does not fail the required `ci` jobs; fix or re-run that workflow. Do not
+add `musl` as a required PR status.
+
 ### Required before a code commit
 
 From `nix-shell` (or the same **rustc 1.95** class CI pins). The shell sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ before 1.0).
 
 ## [Unreleased]
 
+### Added
+
+- **CI musl artifacts:** after a green `ci` run on `master`/`main`, workflow
+  `musl` builds `nix build .#rbitcoin-musl` and uploads
+  `rbitcoin-node` / `rbitcoin-cli` + `SHA256SUMS` (90 days). Not a required
+  PR check. Manual retry: Actions → musl → Run workflow.
+
 ### Fixed
 
 - **Tests:** scripts-phase steal-worker pin records the coordinator thread on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ nix build .#rbitcoin-musl
 
 See [`docs/reproducible-builds.md`](./docs/reproducible-builds.md).
 
+Green **push** CI on `master`/`main` also runs [`.github/workflows/musl.yml`](./.github/workflows/musl.yml)
+and uploads `rbitcoin-musl-x86_64-linux-<sha>` (90 days). That is a snapshot,
+not the byte-identity gate (`repro-check.sh`). Download from the **musl**
+check on the commit, not from the `ci` run.
+
 ## Commits
 
 - Small, reviewable commits with complete sentences in the message body.

--- a/OPERATOR.md
+++ b/OPERATOR.md
@@ -29,6 +29,13 @@ that produces a Nix-glibc dynamic link that fails outside the store. Dev/test
 builds stay on `nix develop` / `cargo test`; release is always musl static.
 See [`docs/reproducible-builds.md`](./docs/reproducible-builds.md).
 
+**CI snapshots:** every green `master` (or `main`) `ci` run starts workflow
+`musl`, which uploads `rbitcoin-musl-x86_64-linux-<12-hex>` (`rbitcoin-node`,
+`rbitcoin-cli`, `SHA256SUMS`) on that Actions run (90-day retention). Open the
+commit → Checks → **musl** → Artifacts. Not a required PR check. Retry from
+Actions → musl → Run workflow. Local `target/release/` install is still
+`nix build .#rbitcoin-musl` on a clean master tree.
+
 ## CLI (operator-first)
 
 Routine knobs are **CLI / conf**, not required env vars. Clean smoke:

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ cargo test --workspace
 ```
 
 Operator binary: always the static install under `./target/release/` (or
-`./result/bin/`). Operator knobs: [`OPERATOR.md`](./OPERATOR.md). Experimental
-mainnet: [`docs/experimental-mainnet.md`](./docs/experimental-mainnet.md).
+`./result/bin/`). After green `master` CI, the **musl** workflow uploads the
+same pair as an Actions artifact (see [`OPERATOR.md`](./OPERATOR.md)).
+Operator knobs: [`OPERATOR.md`](./OPERATOR.md). Experimental mainnet:
+[`docs/experimental-mainnet.md`](./docs/experimental-mainnet.md).
 
 ## Crate map
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -188,6 +188,7 @@ audit closures. Do not reopen without new evidence.
 | `#[test]` / `#[tokio::test]` | **~1.15k** |
 | Coverage gate | **≥90%** LCOV `LH`/`LF` (required CI) |
 | Required CI | `fmt`, `deny`, `clippy`, `test`, `multinode`, `coverage` (+ CodeQL workflow) |
+| Extra CI | `musl` workflow after green master `ci` (artifact upload; not required) |
 | rustc | **1.95** (`Cargo.toml` + `rust-toolchain.toml` + `dtolnay/rust-toolchain@1.95.0` + nixos-26.05 / shell) |
 | Nix | **nixos-26.05** + crane **0.23.x** |
 | Host cargo silos | `target/dev` (test) / `target/cov` (coverage) |

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -74,6 +74,14 @@ path is the same for both packages.
 Day-to-day: one `nix build .#rbitcoin-musl` (or `./scripts/repro-build.sh`).
 After the deps layer is in the store, app-only changes rebuild far less.
 
+**GitHub Actions:** [`.github/workflows/musl.yml`](../.github/workflows/musl.yml)
+runs that same one-build path after a **green** `ci` **push** to `master`/`main`
+(and on `workflow_dispatch`). It stages with
+`scripts/stage-musl-artifacts.sh` (`file(1)` must say statically linked) and
+uploads `rbitcoin-node`, `rbitcoin-cli`, `SHA256SUMS` as
+`rbitcoin-musl-x86_64-linux-<12-sha>`. Not a required check; not
+`repro-check.sh`.
+
 **Byte-identity gate** (`./scripts/repro-check.sh`) still forces two clean
 `--rebuild`s — use it for release verification, not every commit.
 

--- a/scripts/stage-musl-artifacts.sh
+++ b/scripts/stage-musl-artifacts.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copy musl node/cli from a nix result dir and refuse anything not static.
+#
+# Usage:
+#   ./scripts/stage-musl-artifacts.sh RESULT_DIR DEST_DIR
+#
+# RESULT_DIR is the `nix build .#rbitcoin-musl --out-link` path (binaries in
+# bin/). DEST_DIR receives rbitcoin-node, rbitcoin-cli, and SHA256SUMS.
+# `file(1)` must report statically linked (or static-pie).
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 RESULT_DIR DEST_DIR" >&2
+  exit 2
+fi
+
+RESULT="$1"
+DEST="$2"
+
+if ! command -v file >/dev/null 2>&1; then
+  echo "error: file(1) is required to verify a static musl link" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+
+for b in rbitcoin-node rbitcoin-cli; do
+  src="$RESULT/bin/$b"
+  if [[ ! -e "$src" ]]; then
+    echo "error: missing $src" >&2
+    exit 1
+  fi
+  desc="$(file -b "$src" || true)"
+  if ! grep -Eiq 'statically linked|static-pie' <<<"$desc"; then
+    echo "error: $b is not statically linked: $desc" >&2
+    exit 1
+  fi
+  install -m 755 "$src" "$DEST/$b"
+done
+
+(
+  cd "$DEST"
+  sha256sum rbitcoin-node rbitcoin-cli >SHA256SUMS
+)
+
+echo "stage-musl-artifacts: $DEST"
+cat "$DEST/SHA256SUMS"

--- a/scripts/stage-musl-artifacts.test.sh
+++ b/scripts/stage-musl-artifacts.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Contract pin for scripts/stage-musl-artifacts.sh (no Nix / no musl compile).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAGE="$ROOT/scripts/stage-musl-artifacts.sh"
+PASS=0
+FAIL=0
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "ok - $name"
+    PASS=$((PASS + 1))
+  else
+    echo "not ok - $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "not ok - $name (expected failure)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "ok - $name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/rbitcoin-stage-musl.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+MOCK="$WORKDIR/mockbin"
+mkdir -p "$MOCK"
+
+# file(1) stub: MODE=static|dynamic via env (default static).
+cat >"$MOCK/file" <<'EOF'
+#!/usr/bin/env bash
+shift || true
+if [[ "${MOCK_FILE_MODE:-static}" == "dynamic" ]]; then
+  echo "ELF 64-bit LSB pie executable, x86-64, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2"
+else
+  echo "ELF 64-bit LSB executable, x86-64, statically linked, stripped"
+fi
+EOF
+chmod +x "$MOCK/file"
+
+RESULT="$WORKDIR/result"
+DEST="$WORKDIR/dist"
+mkdir -p "$RESULT/bin"
+printf 'node-bytes\n' >"$RESULT/bin/rbitcoin-node"
+printf 'cli-bytes\n' >"$RESULT/bin/rbitcoin-cli"
+chmod +x "$RESULT/bin/rbitcoin-node" "$RESULT/bin/rbitcoin-cli"
+
+export PATH="$MOCK:$PATH"
+
+assert_ok "script exists" test -x "$STAGE"
+
+assert_ok "static pair stages" env MOCK_FILE_MODE=static "$STAGE" "$RESULT" "$DEST"
+assert_ok "copied node" test -f "$DEST/rbitcoin-node"
+assert_ok "copied cli" test -f "$DEST/rbitcoin-cli"
+assert_ok "sha256sums present" test -s "$DEST/SHA256SUMS"
+assert_ok "sha256sums names node" grep -q 'rbitcoin-node' "$DEST/SHA256SUMS"
+assert_ok "sha256sums names cli" grep -q 'rbitcoin-cli' "$DEST/SHA256SUMS"
+
+rm -rf "$DEST"
+assert_fail "dynamic link is refused" env MOCK_FILE_MODE=dynamic "$STAGE" "$RESULT" "$DEST"
+
+rm -rf "$DEST"
+rm -f "$RESULT/bin/rbitcoin-cli"
+assert_fail "missing binary is refused" env MOCK_FILE_MODE=static "$STAGE" "$RESULT" "$DEST"
+
+echo
+echo "passed=$PASS failed=$FAIL"
+test "$FAIL" -eq 0


### PR DESCRIPTION
Every successful ci push to master/main starts the musl workflow: nix build .#rbitcoin-musl, refuse a non-static link, upload node/cli and SHA256SUMS. Not a required PR check. Local operator install is unchanged.