### PR TITLE
store: restore open+3 as head-resolve wave 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ before 1.0).
 
 ### Fixed
 
+- **Head resolve 2-wave:** wave 1 is open + sealed ages ≤3 again. The spend-only
+  DONTCACHE change had made `head_or_idx_segment_index` always false, so hot
+  probed every segment and cold was empty. Unconnected hot hits still run
+  wave 2 so `TipThenAny` / `TipOnly` can take a connected sibling in age ≥4.
+
 - **Tests:** scripts-phase steal-worker pin records the coordinator thread on
   the handle (not a process-global name). Archive plan/commit wall stats sample
   under an exclusive lock so parallel `sample_and_reset` cannot steal the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ before 1.0).
 - **Tests:** scripts-phase steal-worker pin records the coordinator thread on
   the handle (not a process-global name). Archive plan/commit wall stats sample
   under an exclusive lock so parallel `sample_and_reset` cannot steal the
-  window.
+  window. Head soft-span override is thread-local so a sibling
+  `test_set_soft_span_bytes(0)` cannot reset another test's 48-byte roll
+  window (`tip_then_any_connected_in_cold_beats_unconnected_hot`).
 
 ### Changed
 

--- a/crates/rbitcoin-store/src/dontcache_policy.rs
+++ b/crates/rbitcoin-store/src/dontcache_policy.rs
@@ -69,6 +69,8 @@ pub fn sealed_age_from_index(si: usize, n_segs: usize) -> u32 {
     n_segs.saturating_sub(1).saturating_sub(si) as u32
 }
 
+/// Page-cache flag only. **Not** the two-wave probe split (that is
+/// [`sealed_age_from_index`] vs [`crate::segmented_head::HEAD_PROBE_HOT_MAX_AGE`]).
 #[inline]
 pub fn head_or_idx_segment_index(_si: usize, _n_segs: usize) -> bool {
     false

--- a/crates/rbitcoin-store/src/head_resolve_denserels.rs
+++ b/crates/rbitcoin-store/src/head_resolve_denserels.rs
@@ -870,39 +870,40 @@ mod tests {
     /// via `first_fks` and only require the process counters moved for age 0.
     #[test]
     fn resolve_records_winner_age_open_segment() {
-        crate::segmented_head::SegmentedTxHead::test_set_soft_span_bytes(0);
-        let _ = crate::head_resolve_stats::sample_and_reset();
-        let (dir, t, txids) = seed_table(16);
-        assert_eq!(
-            t.head.segment_count(),
-            1,
-            "unexpected segs={}",
-            t.head.segment_count()
-        );
-        let first = t.head.first_fks_snapshot();
-        assert_eq!(first, vec![1]);
-        let got = resolve_fk_and_range_batch(&t, &txids).unwrap();
-        let hits = got.iter().filter(|(_, r)| r.is_some()).count() as u64;
-        assert_eq!(hits, txids.len() as u64);
-        for (_tid, row) in &got {
-            if let Some((fk, _)) = row {
-                assert_eq!(
-                    crate::head_resolve_stats::sealed_age_for_fk(&first, fk.0),
-                    Some(0),
-                    "fk={}",
-                    fk.0
-                );
+        crate::segmented_head::SegmentedTxHead::test_with_soft_span_bytes(0, || {
+            let _ = crate::head_resolve_stats::sample_and_reset();
+            let (dir, t, txids) = seed_table(16);
+            assert_eq!(
+                t.head.segment_count(),
+                1,
+                "unexpected segs={}",
+                t.head.segment_count()
+            );
+            let first = t.head.first_fks_snapshot();
+            assert_eq!(first, vec![1]);
+            let got = resolve_fk_and_range_batch(&t, &txids).unwrap();
+            let hits = got.iter().filter(|(_, r)| r.is_some()).count() as u64;
+            assert_eq!(hits, txids.len() as u64);
+            for (_tid, row) in &got {
+                if let Some((fk, _)) = row {
+                    assert_eq!(
+                        crate::head_resolve_stats::sealed_age_for_fk(&first, fk.0),
+                        Some(0),
+                        "fk={}",
+                        fk.0
+                    );
+                }
             }
-        }
-        let s = crate::head_resolve_stats::sample_and_reset();
-        // Our hits are age 0; concurrent resolve tests may add more age-0 counts.
-        assert!(
-            s.age_hit[0] >= hits,
-            "age0={} hits={hits} age_hit={:?}",
-            s.age_hit[0],
-            &s.age_hit[..8]
-        );
-        let _ = std::fs::remove_dir_all(&dir);
+            let s = crate::head_resolve_stats::sample_and_reset();
+            // Our hits are age 0; concurrent resolve tests may add more age-0 counts.
+            assert!(
+                s.age_hit[0] >= hits,
+                "age0={} hits={hits} age_hit={:?}",
+                s.age_hit[0],
+                &s.age_hit[..8]
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     /// On a small (no cold segs) store, hot∪cold cands equal full probe.

--- a/crates/rbitcoin-store/src/head_resolve_denserels.rs
+++ b/crates/rbitcoin-store/src/head_resolve_denserels.rs
@@ -1,11 +1,12 @@
 //! Plan Shape A head resolve: **txids in → denserels out** (or fk+range short-circuit).
 //!
 //! Schema **13+** two waves on probe (uring when available):
-//! 1. **Hot probe** — page-coalesced loads for non-DONTCACHE segs (ages ≤3) → cands
+//! 1. **Hot probe** — open + sealed ages ≤3 → cands
 //! 2. **ID / IDX** — page-grouped `txid.body` identity fill, then depth-first BIP30
 //!    match in RAM + **one** page-grouped `txout.idx` fill for chosen fks
-//! 3. If any key still unmatched: **cold probe** (DONTCACHE segs ages ≥4) for
-//!    survivors only → full cand list → ID/IDX again
+//! 3. If any key still unmatched **or** (fence on and hot hit unconnected):
+//!    **cold probe** (sealed ages ≥4) for those keys → ID/IDX again
+//!    (`TipThenAny` can still take a connected sibling in cold)
 //! 4. **denserels** (optional) — packed body when outs are needed
 //!
 //! [`resolve_fk_and_range_batch`] is the **stamp short-circuit**: stops after
@@ -921,6 +922,87 @@ mod tests {
         }
         // Tiny store: everything is hot; cold must be empty.
         assert!(cold.iter().all(|c| c.is_empty()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Wave 1 is open + sealed ages ≤3; ages ≥4 are cold only. hot∪cold = full.
+    #[test]
+    fn hot_wave_is_open_plus_three_sealed() {
+        use crate::address_head::HeadLayout;
+        use crate::segmented_head::HEAD_PROBE_HOT_MAX_AGE;
+        let dir = tmp("hot-open-plus-3");
+        let layout = HeadLayout::with_entry_bytes(8, 4).unwrap();
+        let t = TxTable::create_with_head_layout(&dir, layout).unwrap();
+        // bits=8 → 256 slots, seal ~204 keys. Six segments ⇒ oldest age ≥4.
+        let n = 204u32.saturating_mul(6);
+        let mut items = Vec::new();
+        let mut txids = Vec::new();
+        for i in 0..n {
+            let mut tid = [0u8; 32];
+            tid[0..4].copy_from_slice(&i.to_le_bytes());
+            tid[8] = 0xa5;
+            txids.push(tid);
+            items.push((
+                TxRecord {
+                    txid: tid,
+                    version: 1,
+                    locktime: 0,
+                    input_start_fk: Fk::NULL,
+                    input_count: 1,
+                    output_start_fk: Fk::NULL,
+                    output_count: 1,
+                },
+                vec![InputRecord::coinbase(u32::MAX, vec![], vec![])],
+                vec![OutputRecord::unspent(1, vec![0x51])],
+            ));
+        }
+        t.put_full_batch_indexed(&items, true).unwrap();
+        assert!(
+            t.head.sealed_segment_count() >= 4,
+            "need a cold sealed age, segs={} sealed={}",
+            t.head.segment_count(),
+            t.head.sealed_segment_count()
+        );
+        let first = t.head.first_fks_snapshot();
+        let mixed: Vec<[u8; 32]> = txids.iter().map(|x| t.secret.mix_txid(x)).collect();
+        let hot = t.head.probe_candidates_batch_hot(&mixed).unwrap();
+        let active = vec![true; mixed.len()];
+        let cold = t.head.probe_candidates_batch_cold(&mixed, &active).unwrap();
+        let full = t.head.probe_candidates_batch(&mixed).unwrap();
+        let mut saw_cold = false;
+        for i in 0..txids.len() {
+            let mut merged = hot[i].clone();
+            merged.extend(cold[i].iter().copied());
+            assert_eq!(merged, full[i], "hot∪cold must equal full probe i={i}");
+            for &fk in &hot[i] {
+                let age = crate::head_resolve_stats::sealed_age_for_fk(&first, fk.0).unwrap();
+                assert!(
+                    age <= HEAD_PROBE_HOT_MAX_AGE,
+                    "hot cand fk={} age={age}",
+                    fk.0
+                );
+            }
+            for &fk in &cold[i] {
+                let age = crate::head_resolve_stats::sealed_age_for_fk(&first, fk.0).unwrap();
+                assert!(
+                    age > HEAD_PROBE_HOT_MAX_AGE,
+                    "cold cand fk={} age={age}",
+                    fk.0
+                );
+                saw_cold = true;
+            }
+        }
+        assert!(saw_cold, "expected some keys to have cold-only cands");
+        let oldest = crate::head_resolve_stats::sealed_age_for_fk(&first, 1).unwrap();
+        assert!(oldest > HEAD_PROBE_HOT_MAX_AGE, "oldest age={oldest}");
+        assert!(
+            !hot[0].iter().any(|f| f.0 == 1),
+            "oldest create must not be in hot"
+        );
+        assert!(
+            cold[0].iter().any(|f| f.0 == 1),
+            "oldest create must be in cold"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/rbitcoin-store/src/segmented_head.rs
+++ b/crates/rbitcoin-store/src/segmented_head.rs
@@ -407,6 +407,22 @@ impl SegmentedTxHead {
         TEST_SOFT_SPAN_OVERRIDE.store(bytes, Ordering::Relaxed);
     }
 
+    /// Hold the process-local soft-span override for `f`, then restore.
+    #[cfg(test)]
+    pub fn test_with_soft_span_bytes<R>(bytes: u64, f: impl FnOnce() -> R) -> R {
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = TEST_SOFT_SPAN_OVERRIDE.swap(bytes, Ordering::Relaxed);
+        struct Restore(u64);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                TEST_SOFT_SPAN_OVERRIDE.store(self.0, Ordering::Relaxed);
+            }
+        }
+        let _restore = Restore(prev);
+        f()
+    }
+
     fn segments_snapshot(&self) -> Arc<Vec<Arc<Segment>>> {
         Arc::clone(&self.segments.read().unwrap_or_else(|e| e.into_inner()))
     }
@@ -486,14 +502,20 @@ impl SegmentedTxHead {
     }
 }
 
+/// Wave-1 sealed-age cap: open (age 0) + sealed ages `1..=` this.
+///
+/// Independent of [`crate::dontcache_policy::head_or_idx_segment_index`]
+/// (that flag is spend-annotate pwrite only and is always false for head).
+pub(crate) const HEAD_PROBE_HOT_MAX_AGE: u32 = 3;
+
 /// Which head segments to probe (two-wave resolve vs full baseline).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum HeadProbeWave {
     /// Open + all sealed (legacy full probe).
     All,
-    /// Non-DONTCACHE only (ages ≤3): open + up to 3 sealed.
+    /// Open + sealed ages ≤ [`HEAD_PROBE_HOT_MAX_AGE`].
     Hot,
-    /// DONTCACHE sealed only (ages ≥4).
+    /// Sealed ages > [`HEAD_PROBE_HOT_MAX_AGE`].
     Cold,
 }
 
@@ -503,13 +525,13 @@ impl HeadProbeWave {
         matches!(self, HeadProbeWave::All | HeadProbeWave::Hot)
     }
 
-    /// `dc` = [`crate::dontcache_policy::head_or_idx_segment_index`] for the seg.
+    /// `age` = [`crate::dontcache_policy::sealed_age_from_index`] for the seg.
     #[inline]
-    fn includes_seg(self, dontcache: bool) -> bool {
+    fn includes_sealed_age(self, age: u32) -> bool {
         match self {
             HeadProbeWave::All => true,
-            HeadProbeWave::Hot => !dontcache,
-            HeadProbeWave::Cold => dontcache,
+            HeadProbeWave::Hot => age <= HEAD_PROBE_HOT_MAX_AGE,
+            HeadProbeWave::Cold => age > HEAD_PROBE_HOT_MAX_AGE,
         }
     }
 }
@@ -544,7 +566,7 @@ impl SegmentedTxHead {
         self.probe_candidates_batch_inner(mixed, Some(session), HeadProbeWave::All, None)
     }
 
-    /// Two-wave resolve: probe only **hot** (non-DONTCACHE) segments for all keys.
+    /// Two-wave resolve: probe only **hot** (open + sealed ages ≤3) for all keys.
     pub(crate) fn probe_candidates_batch_hot(
         &self,
         mixed: &[[u8; 32]],
@@ -561,8 +583,9 @@ impl SegmentedTxHead {
         self.probe_candidates_batch_inner(mixed, Some(session), HeadProbeWave::Hot, None)
     }
 
-    /// Two-wave resolve: probe only **cold** (DONTCACHE) segments for keys where
-    /// `active[i]` is true (wave-1 misses). Inactive keys get empty cand lists.
+    /// Two-wave resolve: probe only **cold** (sealed ages ≥4) for keys where
+    /// `active[i]` is true (wave-1 misses / unconnected hot). Inactive keys
+    /// get empty cand lists.
     pub(crate) fn probe_candidates_batch_cold(
         &self,
         mixed: &[[u8; 32]],
@@ -607,7 +630,7 @@ impl SegmentedTxHead {
 
         let n_segs = segs.len();
         let last = segs.last().unwrap();
-        // Open is always age 0 → never DONTCACHE → hot only (not cold).
+        // Open is always age 0 → wave 1 only (not cold).
         if !last.sealed && wave.includes_hot() {
             let mut pass_i: Vec<usize> = Vec::new();
             let mut pass_keys: Vec<[u8; 32]> = Vec::new();
@@ -649,10 +672,12 @@ impl SegmentedTxHead {
             if !seg.sealed {
                 continue;
             }
-            let dc = crate::dontcache_policy::head_or_idx_segment_index(si, n_segs);
-            if !wave.includes_seg(dc) {
+            let age = crate::dontcache_policy::sealed_age_from_index(si, n_segs);
+            if !wave.includes_sealed_age(age) {
                 continue;
             }
+            // Page-cache flag only (always false under spend-pwrite DONTCACHE).
+            let dc = crate::dontcache_policy::head_or_idx_segment_index(si, n_segs);
             let Some(fuse) = seg.fuse.as_ref() else {
                 return Err(StoreError::Corrupt("sealed segment missing fuse"));
             };

--- a/crates/rbitcoin-store/src/segmented_head.rs
+++ b/crates/rbitcoin-store/src/segmented_head.rs
@@ -58,10 +58,13 @@ static LOOKUP_SEALED_PROBE: AtomicU64 = AtomicU64::new(0);
 static ROLLS: AtomicU64 = AtomicU64::new(0);
 static SEALS: AtomicU64 = AtomicU64::new(0);
 
-/// Test-only soft-span override (bytes). Non-zero wins over env so parallel
-/// `RBITCOIN_TX_IDX_SOFT_SPAN` mutators in other modules cannot desync this path.
+// Test-only soft-span override (bytes). Thread-local: a sibling test that
+// `test_set_soft_span_bytes(0)` must not reset this thread's roll window.
+// Non-zero wins over env.
 #[cfg(test)]
-static TEST_SOFT_SPAN_OVERRIDE: AtomicU64 = AtomicU64::new(0);
+thread_local! {
+    static TEST_SOFT_SPAN_OVERRIDE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
 
 pub fn sample_lookup_stats() -> HeadLookupStats {
     HeadLookupStats {
@@ -378,14 +381,12 @@ impl SegmentedTxHead {
     /// Body soft-span roll threshold (bytes). Same default as `tx.idx`.
     ///
     /// Production: env `RBITCOIN_TX_IDX_SOFT_SPAN` (min 8). Under test,
-    /// [`test_set_soft_span_bytes`] overrides env when non-zero so parallel
-    /// modules that also poke the env cannot race this path.
+    /// [`test_with_soft_span_bytes`] overrides env when non-zero (thread-local
+    /// so parallel store tests cannot steal each other's roll window).
     pub fn soft_span_bytes() -> u64 {
-        // Process-local override wins in tests so parallel env mutators cannot
-        // desync this path. Env is next; then the production default.
         #[cfg(test)]
         {
-            let o = TEST_SOFT_SPAN_OVERRIDE.load(Ordering::Relaxed);
+            let o = TEST_SOFT_SPAN_OVERRIDE.with(std::cell::Cell::get);
             if o > 0 {
                 return o;
             }
@@ -400,23 +401,21 @@ impl SegmentedTxHead {
         DEFAULT_SOFT_SPAN
     }
 
-    /// Test-only soft-span override (`0` = use env/default). Process-local;
-    /// preferred over env for concurrent store unit tests.
+    /// Test-only soft-span override (`0` = use env/default). Thread-local.
+    /// Prefer [`test_with_soft_span_bytes`] so panic/restore cannot leak.
     #[cfg(test)]
     pub fn test_set_soft_span_bytes(bytes: u64) {
-        TEST_SOFT_SPAN_OVERRIDE.store(bytes, Ordering::Relaxed);
+        TEST_SOFT_SPAN_OVERRIDE.with(|c| c.set(bytes));
     }
 
-    /// Hold the process-local soft-span override for `f`, then restore.
+    /// Hold this thread's soft-span override for `f`, then restore.
     #[cfg(test)]
     pub fn test_with_soft_span_bytes<R>(bytes: u64, f: impl FnOnce() -> R) -> R {
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev = TEST_SOFT_SPAN_OVERRIDE.swap(bytes, Ordering::Relaxed);
+        let prev = TEST_SOFT_SPAN_OVERRIDE.with(|c| c.replace(bytes));
         struct Restore(u64);
         impl Drop for Restore {
             fn drop(&mut self) {
-                TEST_SOFT_SPAN_OVERRIDE.store(self.0, Ordering::Relaxed);
+                TEST_SOFT_SPAN_OVERRIDE.with(|c| c.set(self.0));
             }
         }
         let _restore = Restore(prev);
@@ -1124,6 +1123,28 @@ mod tests {
         m[0..8].copy_from_slice(&i.to_le_bytes());
         m[8] = 0xA5;
         m
+    }
+
+    /// Sibling tests used to `test_set_soft_span_bytes(0)` on a process-global
+    /// Atomic and steal the 48-byte roll window from
+    /// `tip_then_any_connected_in_cold_beats_unconnected_hot` (stuck at age=2).
+    #[test]
+    fn soft_span_override_is_thread_local() {
+        SegmentedTxHead::test_with_soft_span_bytes(48, || {
+            assert_eq!(SegmentedTxHead::soft_span_bytes(), 48);
+            let other = std::thread::spawn(SegmentedTxHead::soft_span_bytes)
+                .join()
+                .expect("join");
+            assert_eq!(
+                SegmentedTxHead::soft_span_bytes(),
+                48,
+                "holding thread keeps its override"
+            );
+            assert_ne!(
+                other, 48,
+                "sibling thread must not inherit this test's override (got {other})"
+            );
+        });
     }
 
     #[test]

--- a/crates/rbitcoin-store/src/store.rs
+++ b/crates/rbitcoin-store/src/store.rs
@@ -2082,6 +2082,139 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Connected sibling in a **cold** sealed age must beat a newer unconnected
+    /// hot hit (`TipThenAny` and `TipOnly`). Wave 1 is only open+3; skipping
+    /// wave 2 after an unconnected hot cand would regress to the newer row.
+    #[test]
+    fn tip_then_any_connected_in_cold_beats_unconnected_hot() {
+        use crate::head_resolve_stats::sealed_age_for_fk;
+        use crate::segmented_head::{SegmentedTxHead, HEAD_PROBE_HOT_MAX_AGE};
+        use crate::tx_table::OutputRecord;
+
+        fn put_one(s: &Store, txid: [u8; 32], lock: u32) -> Fk {
+            let rec = TxRecord {
+                txid,
+                version: 1,
+                locktime: lock,
+                input_start_fk: Fk::NULL,
+                input_count: 0,
+                output_start_fk: Fk::NULL,
+                output_count: 1,
+            };
+            let out = vec![OutputRecord::unspent(1, vec![0x51; 96])];
+            s.put_tx_full_batch_indexed(&[(rec, vec![], out)], true)
+                .unwrap()[0]
+        }
+
+        SegmentedTxHead::test_with_soft_span_bytes(48, || {
+            let dir = tmp();
+            let s = Store::create(&dir).unwrap();
+            let txid = [0xCDu8; 32];
+            let old = put_one(&s, txid, 1);
+            let mut n = 10u64;
+            let mut guard = 0u32;
+            loop {
+                let first = s.txs.head.first_fks_snapshot();
+                let age = sealed_age_for_fk(&first, old.0).unwrap_or(0);
+                if age > HEAD_PROBE_HOT_MAX_AGE && s.txs.head.sealed_segment_count() >= 4 {
+                    break;
+                }
+                let mut dummy = [0u8; 32];
+                dummy[0..8].copy_from_slice(&n.to_le_bytes());
+                dummy[15] = 0xee;
+                let _ = put_one(&s, dummy, n as u32);
+                n += 1;
+                guard += 1;
+                assert!(
+                    guard < 80,
+                    "could not roll oldest create into cold age (age={age} segs={})",
+                    s.txs.head.segment_count()
+                );
+            }
+            let new = put_one(&s, txid, 2);
+            assert_ne!(old, new);
+            let first = s.txs.head.first_fks_snapshot();
+            let age_old = sealed_age_for_fk(&first, old.0).unwrap();
+            let age_new = sealed_age_for_fk(&first, new.0).unwrap();
+            assert!(
+                age_old > HEAD_PROBE_HOT_MAX_AGE,
+                "old fk must sit in cold age={age_old}"
+            );
+            assert!(
+                age_new <= HEAD_PROBE_HOT_MAX_AGE,
+                "new fk must sit in hot age={age_new}"
+            );
+
+            let mixed = [s.txs.secret.mix_txid(&txid)];
+            let hot = s.txs.head.probe_candidates_batch_hot(&mixed).unwrap();
+            let cold = s
+                .txs
+                .head
+                .probe_candidates_batch_cold(&mixed, &[true])
+                .unwrap();
+            assert!(
+                hot[0].iter().any(|f| *f == new) && !hot[0].iter().any(|f| *f == old),
+                "hot={:?} new={new:?} old={old:?}",
+                hot[0]
+            );
+            assert!(
+                cold[0].iter().any(|f| *f == old) && !cold[0].iter().any(|f| *f == new),
+                "cold={:?} old={old:?} new={new:?}",
+                cold[0]
+            );
+
+            // Neither connected yet: newest unconnected (hot) for TipThenAny.
+            assert_eq!(
+                s.resolve_txid(&txid, TxidResolveMode::TipThenAny).unwrap(),
+                Some(new)
+            );
+            assert_eq!(
+                s.get_fk_by_txid_batch_mode(&[txid], TxidResolveMode::TipThenAny)
+                    .unwrap()[0]
+                    .1
+                    .map(|(f, _)| f),
+                Some(new),
+                "batch TipThenAny must keep newer unconnected when cold has no connected"
+            );
+            assert_eq!(
+                s.get_fk_by_txid_batch_mode(&[txid], TxidResolveMode::TipOnly)
+                    .unwrap()[0]
+                    .1,
+                None
+            );
+
+            s.header_txs.put_range(Fk(1), old, 1).unwrap();
+            s.confirmed.set(Height(0), Fk(1)).unwrap();
+            s.rebuild_height_fence().unwrap();
+
+            assert_eq!(
+                s.resolve_txid(&txid, TxidResolveMode::TipOnly).unwrap(),
+                Some(old)
+            );
+            assert_eq!(
+                s.resolve_txid(&txid, TxidResolveMode::TipThenAny).unwrap(),
+                Some(old)
+            );
+            let batch_tip = s
+                .get_fk_by_txid_batch_mode(&[txid], TxidResolveMode::TipOnly)
+                .unwrap();
+            assert_eq!(
+                batch_tip[0].1.map(|(f, _)| f),
+                Some(old),
+                "TipOnly must take connected cold sibling, not unconnected hot"
+            );
+            let batch_any = s
+                .get_fk_by_txid_batch_mode(&[txid], TxidResolveMode::TipThenAny)
+                .unwrap();
+            assert_eq!(
+                batch_any[0].1.map(|(f, _)| f),
+                Some(old),
+                "TipThenAny must take connected cold sibling over newer unconnected hot"
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        });
+    }
+
     #[test]
     fn schema16_create_does_not_write_tx_height_and_fence_has_reorg_holes() {
         let dir = tmp();

--- a/crates/rbitcoin-store/src/store.rs
+++ b/crates/rbitcoin-store/src/store.rs
@@ -2114,6 +2114,11 @@ mod tests {
             let mut n = 10u64;
             let mut guard = 0u32;
             loop {
+                assert_eq!(
+                    SegmentedTxHead::soft_span_bytes(),
+                    48,
+                    "this thread's 48-byte roll window must not be stolen"
+                );
                 let first = s.txs.head.first_fks_snapshot();
                 let age = sealed_age_for_fk(&first, old.0).unwrap_or(0);
                 if age > HEAD_PROBE_HOT_MAX_AGE && s.txs.head.sealed_segment_count() >= 4 {
@@ -2127,8 +2132,9 @@ mod tests {
                 guard += 1;
                 assert!(
                     guard < 80,
-                    "could not roll oldest create into cold age (age={age} segs={})",
-                    s.txs.head.segment_count()
+                    "could not roll oldest create into cold age (age={age} segs={} span={})",
+                    s.txs.head.segment_count(),
+                    SegmentedTxHead::soft_span_bytes()
                 );
             }
             let new = put_one(&s, txid, 2);

--- a/crates/rbitcoin-store/src/tx_table/tests.rs
+++ b/crates/rbitcoin-store/src/tx_table/tests.rs
@@ -2073,122 +2073,36 @@ fn put_full_aligns_record_starts_and_txid_prefix() {
 #[test]
 fn bip30_duplicate_txid_seal_succeeds_and_resolves() {
     with_env_lock(|| {
-        SegmentedTxHead::test_set_soft_span_bytes(0);
-        std::env::remove_var("RBITCOIN_TX_IDX_SOFT_SPAN");
-        let dir = tempfile_dir("bip30-seal");
-        // 10-bit: max_keys = 819
-        let layout = HeadLayout::with_entry_bytes(10, 4).unwrap();
-        let t = TxTable::create_with_head_layout(&dir, layout).unwrap();
-        let mut shared = [0u8; 32];
-        shared[0..8].copy_from_slice(&1u64.to_le_bytes());
-        // Two Class A creates with the same txid (BIP30-shaped).
-        let r1 = TxRecord {
-            txid: shared,
-            version: 1,
-            locktime: 0,
-            input_start_fk: Fk::NULL,
-            input_count: 0,
-            output_start_fk: Fk::NULL,
-            output_count: 0,
-        };
-        let r2 = r1.clone();
-        let fks = t
-            .put_full_batch_indexed(&meta_only_items(&[r1, r2]), true)
-            .unwrap();
-        assert_eq!(fks.len(), 2);
-        assert_ne!(fks[0], fks[1]);
-        // Fill remaining to force seal of first segment (819 creates).
-        let mut rest = Vec::new();
-        for i in 3..=819u64 {
-            let mut txid = [0u8; 32];
-            txid[0..8].copy_from_slice(&i.to_le_bytes());
-            rest.push(TxRecord {
-                txid,
-                version: 1,
-                locktime: 0,
-                input_start_fk: Fk::NULL,
-                input_count: 0,
-                output_start_fk: Fk::NULL,
-                output_count: 0,
-            });
-        }
-        t.put_full_batch_indexed(&meta_only_items(&rest), true)
-            .unwrap();
-        // Next create forces roll/seal of the full segment.
-        let mut more = [0u8; 32];
-        more[0..8].copy_from_slice(&820u64.to_le_bytes());
-        t.put_full_batch_indexed(
-            &meta_only_items(&[TxRecord {
-                txid: more,
-                version: 1,
-                locktime: 0,
-                input_start_fk: Fk::NULL,
-                input_count: 0,
-                output_start_fk: Fk::NULL,
-                output_count: 0,
-            }]),
-            true,
-        )
-        .unwrap();
-        assert!(
-            t.head.sealed_segment_count() >= 1,
-            "seal must succeed despite BIP30 duplicate fuse keys"
-        );
-        // Newest BIP30 create wins (deeper probe).
-        let hit = t.get_fk_by_txid(&shared).unwrap();
-        assert_eq!(hit, Some(fks[1]), "newest same-txid create");
-        let all = t.get_all_by_txid(&shared).unwrap();
-        assert_eq!(all.len(), 2, "both BIP30 creates body-verify");
-        assert_eq!(all[0].0, fks[1]);
-        assert_eq!(all[1].0, fks[0]);
-        let _ = std::fs::remove_dir_all(&dir);
-    });
-}
-
-/// Reopen mid-open-segment, then fill to seal: pre-reopen creates must not FN.
-#[test]
-fn reopen_mid_segment_then_seal_no_fuse_fn() {
-    with_env_lock(|| {
-        // Only load@80% rolls — clear soft-span override/env from sibling tests.
-        SegmentedTxHead::test_set_soft_span_bytes(0);
-        std::env::remove_var("RBITCOIN_TX_IDX_SOFT_SPAN");
-        let dir = tempfile_dir("reopen-seal-fn");
-        // 10-bit: max_keys = floor(0.8*1024) = 819
-        let layout = HeadLayout::with_entry_bytes(10, 4).unwrap();
-        let half = 400u64;
-        {
+        SegmentedTxHead::test_with_soft_span_bytes(0, || {
+            std::env::remove_var("RBITCOIN_TX_IDX_SOFT_SPAN");
+            let dir = tempfile_dir("bip30-seal");
+            // 10-bit: max_keys = 819
+            let layout = HeadLayout::with_entry_bytes(10, 4).unwrap();
             let t = TxTable::create_with_head_layout(&dir, layout).unwrap();
-            let recs: Vec<TxRecord> = (0..half)
-                .map(|i| {
-                    let mut txid = [0u8; 32];
-                    txid[0..8].copy_from_slice(&(i + 1).to_le_bytes());
-                    TxRecord {
-                        txid,
-                        version: 1,
-                        locktime: 0,
-                        input_start_fk: Fk::NULL,
-                        input_count: 0,
-                        output_start_fk: Fk::NULL,
-                        output_count: 0,
-                    }
-                })
-                .collect();
-            t.put_full_batch_indexed(&meta_only_items(&recs), true)
+            let mut shared = [0u8; 32];
+            shared[0..8].copy_from_slice(&1u64.to_le_bytes());
+            // Two Class A creates with the same txid (BIP30-shaped).
+            let r1 = TxRecord {
+                txid: shared,
+                version: 1,
+                locktime: 0,
+                input_start_fk: Fk::NULL,
+                input_count: 0,
+                output_start_fk: Fk::NULL,
+                output_count: 0,
+            };
+            let r2 = r1.clone();
+            let fks = t
+                .put_full_batch_indexed(&meta_only_items(&[r1, r2]), true)
                 .unwrap();
-            assert_eq!(t.head_segment_count(), 1);
-            assert_eq!(t.head.sealed_segment_count(), 0);
-            assert_eq!(t.head.open_keys_len() as u64, half);
-            t.flush().unwrap();
-        }
-        // Reopen: open_keys must rebuild from Class A.
-        let t = TxTable::open(&dir).unwrap();
-        assert_eq!(t.head.open_keys_len() as u64, half, "open keys rebuilt");
-        // Fill past 819 so first segment seals.
-        let more: Vec<TxRecord> = (half..900)
-            .map(|i| {
+            assert_eq!(fks.len(), 2);
+            assert_ne!(fks[0], fks[1]);
+            // Fill remaining to force seal of first segment (819 creates).
+            let mut rest = Vec::new();
+            for i in 3..=819u64 {
                 let mut txid = [0u8; 32];
-                txid[0..8].copy_from_slice(&(i + 1).to_le_bytes());
-                TxRecord {
+                txid[0..8].copy_from_slice(&i.to_le_bytes());
+                rest.push(TxRecord {
                     txid,
                     version: 1,
                     locktime: 0,
@@ -2196,43 +2110,82 @@ fn reopen_mid_segment_then_seal_no_fuse_fn() {
                     input_count: 0,
                     output_start_fk: Fk::NULL,
                     output_count: 0,
-                }
-            })
-            .collect();
-        t.put_full_batch_indexed(&meta_only_items(&more), true)
+                });
+            }
+            t.put_full_batch_indexed(&meta_only_items(&rest), true)
+                .unwrap();
+            // Next create forces roll/seal of the full segment.
+            let mut more = [0u8; 32];
+            more[0..8].copy_from_slice(&820u64.to_le_bytes());
+            t.put_full_batch_indexed(
+                &meta_only_items(&[TxRecord {
+                    txid: more,
+                    version: 1,
+                    locktime: 0,
+                    input_start_fk: Fk::NULL,
+                    input_count: 0,
+                    output_start_fk: Fk::NULL,
+                    output_count: 0,
+                }]),
+                true,
+            )
             .unwrap();
-        assert!(t.head.sealed_segment_count() >= 1, "must have sealed");
-        // Pre-reopen members must resolve through sealed fuse (no FN).
-        for i in [1u64, 50, 200, 400] {
-            let mut txid = [0u8; 32];
-            txid[0..8].copy_from_slice(&i.to_le_bytes());
-            assert_eq!(
-                t.get_fk_by_txid(&txid).unwrap(),
-                Some(Fk(i)),
-                "pre-reopen fk={i} FN after seal"
+            assert!(
+                t.head.sealed_segment_count() >= 1,
+                "seal must succeed despite BIP30 duplicate fuse keys"
             );
-        }
-        for i in [401u64, 820, 900] {
-            let mut txid = [0u8; 32];
-            txid[0..8].copy_from_slice(&i.to_le_bytes());
-            assert_eq!(t.get_fk_by_txid(&txid).unwrap(), Some(Fk(i)), "fk={i}");
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+            // Newest BIP30 create wins (deeper probe).
+            let hit = t.get_fk_by_txid(&shared).unwrap();
+            assert_eq!(hit, Some(fks[1]), "newest same-txid create");
+            let all = t.get_all_by_txid(&shared).unwrap();
+            assert_eq!(all.len(), 2, "both BIP30 creates body-verify");
+            assert_eq!(all[0].0, fks[1]);
+            assert_eq!(all[1].0, fks[0]);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     });
 }
 
-/// Legacy fuse8 v1 → v2 rewrite on open (minimal seal: 820 creates @ bits=10).
+/// Reopen mid-open-segment, then fill to seal: pre-reopen creates must not FN.
 #[test]
-fn reopen_rewrites_legacy_v1_sealed_fuse_to_v2() {
+fn reopen_mid_segment_then_seal_no_fuse_fn() {
     with_env_lock(|| {
-        SegmentedTxHead::test_set_soft_span_bytes(0);
-        std::env::remove_var("RBITCOIN_TX_IDX_SOFT_SPAN");
-        let dir = tempfile_dir("fuse-v1-rewrite");
-        let layout = HeadLayout::with_entry_bytes(10, 4).unwrap();
-        {
-            let t = TxTable::create_with_head_layout(&dir, layout).unwrap();
-            // 0.8 * 1024 slots = 819 → one seal at 820.
-            let recs: Vec<TxRecord> = (0..820u64)
+        // Only load@80% rolls — scoped override so we cannot leak onto this thread.
+        SegmentedTxHead::test_with_soft_span_bytes(0, || {
+            std::env::remove_var("RBITCOIN_TX_IDX_SOFT_SPAN");
+            let dir = tempfile_dir("reopen-seal-fn");
+            // 10-bit: max_keys = floor(0.8*1024) = 819
+            let layout = HeadLayout::with_entry_bytes(10, 4).unwrap();
+            let half = 400u64;
+            {
+                let t = TxTable::create_with_head_layout(&dir, layout).unwrap();
+                let recs: Vec<TxRecord> = (0..half)
+                    .map(|i| {
+                        let mut txid = [0u8; 32];
+                        txid[0..8].copy_from_slice(&(i + 1).to_le_bytes());
+                        TxRecord {
+                            txid,
+                            version: 1,
+                            locktime: 0,
+                            input_start_fk: Fk::NULL,
+                            input_count: 0,
+                            output_start_fk: Fk::NULL,
+                            output_count: 0,
+                        }
+                    })
+                    .collect();
+                t.put_full_batch_indexed(&meta_only_items(&recs), true)
+                    .unwrap();
+                assert_eq!(t.head_segment_count(), 1);
+                assert_eq!(t.head.sealed_segment_count(), 0);
+                assert_eq!(t.head.open_keys_len() as u64, half);
+                t.flush().unwrap();
+            }
+            // Reopen: open_keys must rebuild from Class A.
+            let t = TxTable::open(&dir).unwrap();
+            assert_eq!(t.head.open_keys_len() as u64, half, "open keys rebuilt");
+            // Fill past 819 so first segment seals.
+            let more: Vec<TxRecord> = (half..900)
                 .map(|i| {
                     let mut txid = [0u8; 32];
                     txid[0..8].copy_from_slice(&(i + 1).to_le_bytes());
@@ -2247,37 +2200,87 @@ fn reopen_rewrites_legacy_v1_sealed_fuse_to_v2() {
                     }
                 })
                 .collect();
-            t.put_full_batch_indexed(&meta_only_items(&recs), true)
+            t.put_full_batch_indexed(&meta_only_items(&more), true)
                 .unwrap();
-            assert!(t.head.sealed_segment_count() >= 1);
-            t.flush().unwrap();
-        }
-        let fuse_path = dir.join("tx.head").join("000000.fuse8");
-        assert!(fuse_path.is_file());
-        let mut raw = Vec::from(*b"BF8R");
-        raw.extend_from_slice(&1u32.to_le_bytes()); // VERSION_V1
-        raw.extend_from_slice(&0u64.to_le_bytes());
-        std::fs::write(&fuse_path, &raw).unwrap();
+            assert!(t.head.sealed_segment_count() >= 1, "must have sealed");
+            // Pre-reopen members must resolve through sealed fuse (no FN).
+            for i in [1u64, 50, 200, 400] {
+                let mut txid = [0u8; 32];
+                txid[0..8].copy_from_slice(&i.to_le_bytes());
+                assert_eq!(
+                    t.get_fk_by_txid(&txid).unwrap(),
+                    Some(Fk(i)),
+                    "pre-reopen fk={i} FN after seal"
+                );
+            }
+            for i in [401u64, 820, 900] {
+                let mut txid = [0u8; 32];
+                txid[0..8].copy_from_slice(&i.to_le_bytes());
+                assert_eq!(t.get_fk_by_txid(&txid).unwrap(), Some(Fk(i)), "fk={i}");
+            }
+            let _ = std::fs::remove_dir_all(&dir);
+        });
+    });
+}
 
-        let t = TxTable::open(&dir).unwrap();
-        assert!(
-            t.head.sealed_fuse_rewrite_queue().is_empty(),
-            "open must rewrite legacy fuses before returning"
-        );
-        let bytes = std::fs::read(&fuse_path).unwrap();
-        assert_eq!(&bytes[0..4], b"BF8R");
-        let ver = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
-        assert_eq!(ver, 2, "fuse must be rewritten as v2");
-        for i in [1u64, 100, 400, 819] {
-            let mut txid = [0u8; 32];
-            txid[0..8].copy_from_slice(&i.to_le_bytes());
-            assert_eq!(
-                t.get_fk_by_txid(&txid).unwrap(),
-                Some(Fk(i)),
-                "fk={i} after fuse migrate"
+/// Legacy fuse8 v1 → v2 rewrite on open (minimal seal: 820 creates @ bits=10).
+#[test]
+fn reopen_rewrites_legacy_v1_sealed_fuse_to_v2() {
+    with_env_lock(|| {
+        SegmentedTxHead::test_with_soft_span_bytes(0, || {
+            std::env::remove_var("RBITCOIN_TX_IDX_SOFT_SPAN");
+            let dir = tempfile_dir("fuse-v1-rewrite");
+            let layout = HeadLayout::with_entry_bytes(10, 4).unwrap();
+            {
+                let t = TxTable::create_with_head_layout(&dir, layout).unwrap();
+                // 0.8 * 1024 slots = 819 → one seal at 820.
+                let recs: Vec<TxRecord> = (0..820u64)
+                    .map(|i| {
+                        let mut txid = [0u8; 32];
+                        txid[0..8].copy_from_slice(&(i + 1).to_le_bytes());
+                        TxRecord {
+                            txid,
+                            version: 1,
+                            locktime: 0,
+                            input_start_fk: Fk::NULL,
+                            input_count: 0,
+                            output_start_fk: Fk::NULL,
+                            output_count: 0,
+                        }
+                    })
+                    .collect();
+                t.put_full_batch_indexed(&meta_only_items(&recs), true)
+                    .unwrap();
+                assert!(t.head.sealed_segment_count() >= 1);
+                t.flush().unwrap();
+            }
+            let fuse_path = dir.join("tx.head").join("000000.fuse8");
+            assert!(fuse_path.is_file());
+            let mut raw = Vec::from(*b"BF8R");
+            raw.extend_from_slice(&1u32.to_le_bytes()); // VERSION_V1
+            raw.extend_from_slice(&0u64.to_le_bytes());
+            std::fs::write(&fuse_path, &raw).unwrap();
+
+            let t = TxTable::open(&dir).unwrap();
+            assert!(
+                t.head.sealed_fuse_rewrite_queue().is_empty(),
+                "open must rewrite legacy fuses before returning"
             );
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+            let bytes = std::fs::read(&fuse_path).unwrap();
+            assert_eq!(&bytes[0..4], b"BF8R");
+            let ver = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+            assert_eq!(ver, 2, "fuse must be rewritten as v2");
+            for i in [1u64, 100, 400, 819] {
+                let mut txid = [0u8; 32];
+                txid[0..8].copy_from_slice(&i.to_le_bytes());
+                assert_eq!(
+                    t.get_fk_by_txid(&txid).unwrap(),
+                    Some(Fk(i)),
+                    "fk={i} after fuse migrate"
+                );
+            }
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     });
 }
 
@@ -2311,33 +2314,32 @@ fn soft_span_roll_on_open_segment_not_only_first() {
             let outputs = vec![OutputRecord::unspent(1, vec![0x51; 32])];
             (tx, inputs, outputs)
         };
-        // ~2 fat creates per soft window (process-local override — env races
-        // with other store modules that also set RBITCOIN_TX_IDX_SOFT_SPAN).
-        SegmentedTxHead::test_set_soft_span_bytes(800);
-        for i in 1..=6u64 {
-            t.put_full_batch_indexed(&[mk(i)], true).unwrap();
-        }
-        let segs_mid = t.head_segment_count();
-        let sealed_mid = t.head.sealed_segment_count();
-        assert!(
-            segs_mid >= 2 && sealed_mid >= 1,
-            "first soft rolls segs={segs_mid} sealed={sealed_mid}"
-        );
-        for i in 7..=12u64 {
-            t.put_full_batch_indexed(&[mk(i)], true).unwrap();
-        }
-        let sealed = t.head.sealed_segment_count();
-        assert!(
-            sealed > sealed_mid,
-            "open-segment soft-span must seal again sealed={sealed} mid={sealed_mid} segs={}",
-            t.head_segment_count()
-        );
-        for i in [1u64, 6, 9, 12] {
-            let mut txid = [0u8; 32];
-            txid[0..8].copy_from_slice(&i.to_le_bytes());
-            assert_eq!(t.get_fk_by_txid(&txid).unwrap(), Some(Fk(i)));
-        }
-        SegmentedTxHead::test_set_soft_span_bytes(0);
+        // ~2 fat creates per soft window (thread-local override).
+        SegmentedTxHead::test_with_soft_span_bytes(800, || {
+            for i in 1..=6u64 {
+                t.put_full_batch_indexed(&[mk(i)], true).unwrap();
+            }
+            let segs_mid = t.head_segment_count();
+            let sealed_mid = t.head.sealed_segment_count();
+            assert!(
+                segs_mid >= 2 && sealed_mid >= 1,
+                "first soft rolls segs={segs_mid} sealed={sealed_mid}"
+            );
+            for i in 7..=12u64 {
+                t.put_full_batch_indexed(&[mk(i)], true).unwrap();
+            }
+            let sealed = t.head.sealed_segment_count();
+            assert!(
+                sealed > sealed_mid,
+                "open-segment soft-span must seal again sealed={sealed} mid={sealed_mid} segs={}",
+                t.head_segment_count()
+            );
+            for i in [1u64, 6, 9, 12] {
+                let mut txid = [0u8; 32];
+                txid[0..8].copy_from_slice(&i.to_le_bytes());
+                assert_eq!(t.get_fk_by_txid(&txid).unwrap(), Some(Fk(i)));
+            }
+        });
         let _ = std::fs::remove_dir_all(&dir);
     });
 }

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -28,8 +28,10 @@ Short map of who may write which tables. **Format is unstable until 1.0.**
 **tx.head (segmented):** fixed **25-bit** open-address head per segment with
 **4 B relative** create ids; roll at `MIN(body soft span, 80% slots)`. On seal,
 build **binary fuse8** (~9 bits/key). Open segment has no filter (always probed).
-Lookup: live pipeline pin by txid (same Weak as outs) → open → sealed
-newest→oldest (fuse gate) → body verify. No mono-head resize / overflow sidecar.
+Lookup: live pipeline pin by txid (same Weak as outs) → **hot** (open +
+sealed ages ≤3) → ID/idx; unfinished or unconnected-hot keys then **cold**
+(sealed ages ≥4). Fuse-gates sealed segs. No mono-head resize / overflow
+sidecar. RWF_DONTCACHE is not this split (spend-annotate pwrites only).
 
 **Datadir secret (schema 12):** `store/store.secret` CSPRNG at create. XOR scripts/witness at rest; keyed TXID mix for heads.
 


### PR DESCRIPTION
Wave split was keyed off head_or_idx_segment_index. Spend-only DONTCACHE made that always false, so hot probed every segment and cold was empty. Split on sealed_age_from_index instead: hot is open + ages ≤3, cold is ages ≥4. RWF_DONTCACHE flags stay spend-pwrite only.

Unconnected hot hits still enter wave 2 so TipThenAny/TipOnly can take a connected sibling in an older sealed segment.