### PR TITLE
ci: Windows and Darwin operator snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: cargo build -p rbitcoin-node -p rbitcoin-cli
       - name: stage-musl-artifacts self-test
         run: ./scripts/stage-musl-artifacts.test.sh
+      - name: stage-native-artifacts self-test
+        run: ./scripts/stage-native-artifacts.test.sh
       - name: cargo test
         run: cargo test --workspace
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,7 +70,9 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "short=${sha:0:12}" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
+        with:
+          toolchain: 1.95.0
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,95 @@
+# Darwin operator binaries after a **green** master `ci` run, on
+# `workflow_dispatch`, or on PRs labeled `static-binaries`.
+#
+# Not a required PR check. Apple does not allow a fully static libSystem
+# link, and `nix build` on Darwin is store-linked (not portable). This job
+# uses the pinned rustc on macos-14 and refuses Homebrew / Nix / /usr/local
+# dylibs — only /usr/lib and /System/Library.
+#
+# Artifacts: rbitcoin-aarch64-darwin-<12-sha> (node, cli, SHA256SUMS).
+# Unsigned (no notarization).
+
+name: macos
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or SHA to build (empty = this branch tip)
+        required: false
+        default: ""
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: macos-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  build:
+    name: macos
+    runs-on: macos-14
+    timeout-minutes: 120
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'static-binaries')
+      ) ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        contains(fromJSON('["master", "main"]'), github.event.workflow_run.head_branch) &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
+    env:
+      BUILD_REF: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || inputs.ref || github.sha }}
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_DIR: target/release-darwin
+      RUSTFLAGS: "-C debuginfo=0 -C strip=symbols"
+    steps:
+      - name: Checkout green revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.BUILD_REF }}
+          persist-credentials: false
+
+      - name: Record built SHA
+        id: meta
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "short=${sha:0:12}" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: macos-aarch64
+          workspaces: ". -> target/release-darwin"
+
+      - name: Build node + cli
+        run: cargo build --release -p rbitcoin-node -p rbitcoin-cli
+
+      - name: Stage artifacts
+        run: ./scripts/stage-native-artifacts.sh darwin target/release-darwin/release ./dist
+
+      - name: Upload Darwin binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rbitcoin-aarch64-darwin-${{ steps.meta.outputs.short }}
+          path: |
+            dist/rbitcoin-node
+            dist/rbitcoin-cli
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -7,6 +7,7 @@
 # Triggers:
 #   - workflow_run: `ci` succeeded on a **push** to master/main
 #   - workflow_dispatch: rebuild a ref (retry / operator request)
+#   - pull_request labeled `static-binaries` (not a required check)
 #
 # Artifacts: rbitcoin-musl-x86_64-linux-<12-sha> (node, cli, SHA256SUMS).
 # First run is a cold crane deps layer; later runs restore the Nix store cache.
@@ -23,10 +24,12 @@ on:
         description: Git ref or SHA to build (empty = this branch tip)
         required: false
         default: ""
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
-  group: musl-${{ github.event.workflow_run.head_sha || github.sha }}
-  cancel-in-progress: false
+  group: musl-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -43,14 +46,18 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'static-binaries')
+      ) ||
+      (
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push' &&
         contains(fromJSON('["master", "main"]'), github.event.workflow_run.head_branch) &&
         github.event.workflow_run.head_repository.full_name == github.repository
       )
     env:
-      # workflow_run.head_sha is the green commit. dispatch: input or tip.
-      BUILD_REF: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
+      # workflow_run.head_sha is the green commit. PR: head SHA. dispatch: input or tip.
+      BUILD_REF: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || inputs.ref || github.sha }}
     steps:
       - name: Checkout green revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,8 +73,9 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "short=${sha:0:12}" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
         with:
+          toolchain: 1.95.0
           targets: x86_64-pc-windows-msvc
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,100 @@
+# Windows CRT-static operator binaries after a **green** master `ci` run,
+# on `workflow_dispatch`, or on PRs labeled `static-binaries`.
+#
+# Not a required PR check. Nix cannot produce a portable Windows PE (no
+# musl-style fully static CRT from pkgsStatic). This job uses the pinned
+# rustc on windows-2022 with `-C target-feature=+crt-static` and refuses
+# VC++/MinGW runtime imports.
+#
+# Artifacts: rbitcoin-x86_64-windows-<12-sha> (node.exe, cli.exe, SHA256SUMS).
+
+name: windows
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or SHA to build (empty = this branch tip)
+        required: false
+        default: ""
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: windows-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  actions: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: windows
+    runs-on: windows-2022
+    timeout-minutes: 120
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'static-binaries')
+      ) ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        contains(fromJSON('["master", "main"]'), github.event.workflow_run.head_branch) &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
+    env:
+      BUILD_REF: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || inputs.ref || github.sha }}
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_DIR: target/release-win
+      RUSTFLAGS: "-C target-feature=+crt-static -C debuginfo=0 -C strip=symbols"
+    steps:
+      - name: Checkout green revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.BUILD_REF }}
+          persist-credentials: false
+
+      - name: Record built SHA
+        id: meta
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "short=${sha:0:12}" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: windows-crt-static
+          workspaces: ". -> target/release-win"
+
+      - name: Build CRT-static node + cli
+        run: cargo build --release --target x86_64-pc-windows-msvc -p rbitcoin-node -p rbitcoin-cli
+
+      - name: Stage artifacts
+        run: ./scripts/stage-native-artifacts.sh windows target/release-win/x86_64-pc-windows-msvc/release ./dist
+
+      - name: Upload Windows binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rbitcoin-x86_64-windows-${{ steps.meta.outputs.short }}
+          path: |
+            dist/rbitcoin-node.exe
+            dist/rbitcoin-cli.exe
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,10 @@ Actions is the workspace/coverage/clippy gate.
 ### Push, PR, poll CI
 
 Required jobs: **`fmt`**, **`deny`**, **`clippy`**, **`test`**, **`multinode`**,
-**`coverage`**. `musl.yml` is **not** required. Label **`core-functional`** when
-the PR touches the Core functional harness.
+**`coverage`**. `musl.yml` / `windows.yml` / `macos.yml` are **not** required.
+Label **`core-functional`** when the PR touches the Core functional harness.
+Label **`static-binaries`** to build musl / Windows / Darwin operator
+snapshots on that PR (same jobs as green `master` `ci`).
 
 `origin` stays **SSH**. This VM has **no** GitHub App SSH key. The App token
 from `~/.config/rbitcoin-grok/gh-login.sh` (~1h) is HTTPS-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ before 1.0).
 
 ## [Unreleased]
 
+### Added
+
+- **CI Windows / Darwin snapshots:** after a green `ci` run on
+  `master`/`main` (and on `workflow_dispatch`, and on PRs labeled
+  `static-binaries`), workflows `windows` and `macos` upload CRT-static
+  PE and system-dylib Darwin `rbitcoin-node` / `rbitcoin-cli` +
+  `SHA256SUMS` (90 days). Not required checks. `musl` uses the same
+  label. Linux musl stays Nix; Darwin/Windows are native runners.
+
 ### Changed
 
 - **`ibd: perf` load/script tokens:** `load=` is pin+assemble only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,15 @@ nix build .#rbitcoin-musl
 
 See [`docs/reproducible-builds.md`](./docs/reproducible-builds.md).
 
-Green **push** CI on `master`/`main` also runs [`.github/workflows/musl.yml`](./.github/workflows/musl.yml)
-and uploads `rbitcoin-musl-x86_64-linux-<sha>` (90 days). That is a snapshot,
-not the byte-identity gate (`repro-check.sh`). Download from the **musl**
-check on the commit, not from the `ci` run.
+Green **push** CI on `master`/`main` also runs
+[`.github/workflows/musl.yml`](./.github/workflows/musl.yml),
+[`.github/workflows/windows.yml`](./.github/workflows/windows.yml), and
+[`.github/workflows/macos.yml`](./.github/workflows/macos.yml) and uploads
+90-day snapshots (Linux musl static, Windows CRT-static, Darwin
+system-dylib). That is not the byte-identity gate (`repro-check.sh`).
+Download from those workflow checks on the commit, not from the `ci` run.
+Label a PR **`static-binaries`** to run the same three builds on the PR
+head. Unlabeled PRs keep the cargo gates only.
 
 ## Commits
 

--- a/OPERATOR.md
+++ b/OPERATOR.md
@@ -29,12 +29,21 @@ that produces a Nix-glibc dynamic link that fails outside the store. Dev/test
 builds stay on `nix develop` / `cargo test`; release is always musl static.
 See [`docs/reproducible-builds.md`](./docs/reproducible-builds.md).
 
-**CI snapshots:** every green `master` (or `main`) `ci` run starts workflow
-`musl`, which uploads `rbitcoin-musl-x86_64-linux-<12-hex>` (`rbitcoin-node`,
-`rbitcoin-cli`, `SHA256SUMS`) on that Actions run (90-day retention). Open the
-commit → Checks → **musl** → Artifacts. Not a required PR check. Retry from
-Actions → musl → Run workflow. Local `target/release/` install is still
-`nix build .#rbitcoin-musl` on a clean master tree.
+**CI snapshots:** every green `master` (or `main`) `ci` run starts
+`musl`, `windows`, and `macos`, which upload 90-day artifacts:
+
+| Workflow | Artifact |
+|----------|----------|
+| **musl** | `rbitcoin-musl-x86_64-linux-<12-hex>` — fully static |
+| **windows** | `rbitcoin-x86_64-windows-<12-hex>` — MSVC CRT-static `.exe` |
+| **macos** | `rbitcoin-aarch64-darwin-<12-hex>` — system-dylib only (unsigned) |
+
+Open the commit → Checks → workflow → Artifacts. None of these are
+required PR checks. Retry from Actions → workflow → Run workflow.
+Label a PR **`static-binaries`** to build the same three on that head.
+Local Linux `target/release/` install is still `nix build .#rbitcoin-musl`
+on a clean master tree. Windows IoRing is not supported. Darwin/Windows
+are not Nix packages — see [`docs/reproducible-builds.md`](docs/reproducible-builds.md).
 
 ## CLI (operator-first)
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ Agents implement on a worktree branch and let GitHub Actions run the
 workspace/coverage gates — see [`AGENTS.md`](./AGENTS.md).
 
 Operator binary: always the static install under `./target/release/` (or
-`./result/bin/`). After green `master` CI, the **musl** workflow uploads the
-same pair as an Actions artifact (see [`OPERATOR.md`](./OPERATOR.md)).
+`./result/bin/`). After green `master` CI, **musl** / **windows** /
+**macos** upload operator snapshots (see [`OPERATOR.md`](./OPERATOR.md)).
+Label a PR **`static-binaries`** to build those on the PR head.
 Operator knobs: [`OPERATOR.md`](./OPERATOR.md). Experimental mainnet:
 [`docs/experimental-mainnet.md`](./docs/experimental-mainnet.md).
 

--- a/crates/rbitcoin-store/Cargo.toml
+++ b/crates/rbitcoin-store/Cargo.toml
@@ -14,10 +14,12 @@ rbitcoin-log = { workspace = true }
 bitcoin_hashes = { workspace = true }
 # fallocate / punch-hole for multi‑GiB grows without zero-fill storms (Linux).
 libc = "0.2"
-# Bulk pread submission for head-resolve / confirm body load (Linux).
-io-uring = "0.7"
 # Datadir store.secret CSPRNG.
 getrandom = "0.4"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# Bulk pread submission for head-resolve / confirm body load (Linux).
+io-uring = "0.7"
 # Sealed segment fuse8 is in-tree (`binary_fuse8` + `fuse8_filter`); no xorf/bincode.
 
 [[bin]]

--- a/crates/rbitcoin-store/src/bulk_io.rs
+++ b/crates/rbitcoin-store/src/bulk_io.rs
@@ -28,7 +28,7 @@
 //! Machines stay staged; they do not flatten to one-shot `pread`. See
 //! `docs/io-modality.md` and `docs/concurrency.md`.
 
-use std::os::fd::RawFd;
+use crate::io_handle::IoHandle;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 
 /// SQ/CQ depth for bulk batch sessions.
@@ -36,7 +36,7 @@ const RING_ENTRIES: u32 = crate::uring_session::DEFAULT_ENTRIES;
 
 /// One independent pread. Caller owns `buf` for the full submit/wait.
 pub struct ReadOp<'a> {
-    pub fd: RawFd,
+    pub fd: IoHandle,
     pub offset: u64,
     pub buf: &'a mut [u8],
     /// Filled: bytes read (≥0) or negated errno on failure.
@@ -45,7 +45,7 @@ pub struct ReadOp<'a> {
 
 /// One independent pwrite. Caller owns `buf` for the full submit/wait.
 pub struct WriteOp<'a> {
-    pub fd: RawFd,
+    pub fd: IoHandle,
     pub offset: u64,
     pub buf: &'a [u8],
     /// Filled: bytes written (≥0) or negated errno on failure.
@@ -57,7 +57,7 @@ pub struct WriteOp<'a> {
 /// Test / reusable primitive only — production `tx.head` insert uses other paths.
 #[cfg(test)]
 pub struct PageRmw<'a> {
-    pub fd: RawFd,
+    pub fd: IoHandle,
     pub offset: u64,
     pub buf: &'a mut [u8],
 }
@@ -187,7 +187,7 @@ pub fn pread_batch(ops: &mut [ReadOp<'_>]) {
 
 /// One pread (uring when available). Returns bytes read (≥0) or negated errno.
 #[inline]
-pub fn pread_single(fd: RawFd, offset: u64, buf: &mut [u8]) -> i32 {
+pub fn pread_single(fd: IoHandle, offset: u64, buf: &mut [u8]) -> i32 {
     if buf.is_empty() {
         return 0;
     }
@@ -772,16 +772,9 @@ fn pread_one(op: &mut ReadOp<'_>) {
     }
     let mut got = 0usize;
     while got < op.buf.len() {
-        let n = unsafe {
-            libc::pread(
-                op.fd,
-                op.buf[got..].as_mut_ptr() as *mut libc::c_void,
-                op.buf.len() - got,
-                (op.offset + got as u64) as i64,
-            )
-        };
+        let n = op.fd.pread(op.offset + got as u64, &mut op.buf[got..]);
         if n < 0 {
-            op.result = -std::io::Error::last_os_error().raw_os_error().unwrap_or(5) as i32;
+            op.result = n;
             return;
         }
         if n == 0 {
@@ -806,16 +799,9 @@ fn pwrite_one(op: &mut WriteOp<'_>) {
     }
     let mut got = 0usize;
     while got < op.buf.len() {
-        let n = unsafe {
-            libc::pwrite(
-                op.fd,
-                op.buf[got..].as_ptr() as *const libc::c_void,
-                op.buf.len() - got,
-                (op.offset + got as u64) as i64,
-            )
-        };
+        let n = op.fd.pwrite(op.offset + got as u64, &op.buf[got..]);
         if n < 0 {
-            op.result = -std::io::Error::last_os_error().raw_os_error().unwrap_or(5) as i32;
+            op.result = n;
             return;
         }
         if n == 0 {
@@ -878,13 +864,23 @@ pub fn page_rmw_serial(
 mod tests {
     use super::*;
     use std::io::Write;
-    use std::os::fd::AsRawFd;
+
+    fn dummy_handle() -> IoHandle {
+        #[cfg(unix)]
+        {
+            IoHandle::from_raw_fd(0)
+        }
+        #[cfg(windows)]
+        {
+            IoHandle::from_raw_handle(0)
+        }
+    }
 
     #[test]
     fn pwrite_batch_fail_unfilled_is_not_success() {
         let buf = [1u8; 4];
         let mut ops = [WriteOp {
-            fd: 0,
+            fd: dummy_handle(),
             offset: 0,
             buf: &buf,
             result: i32::MIN,
@@ -928,7 +924,7 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
 
         // Empty bufs
         let mut empty = [];
@@ -1037,7 +1033,7 @@ mod tests {
         f.write_all(&data).unwrap();
         f.flush().unwrap();
         let f = std::fs::File::open(&path).unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
 
         let mut b0 = [0u8; 50];
         let mut b1 = [0u8; 50];
@@ -1113,7 +1109,7 @@ mod tests {
             f.write_all(b"pool-session-bytes!!").unwrap();
             f.flush().unwrap();
             let f = std::fs::File::open(&path).unwrap();
-            let fd = f.as_raw_fd();
+            let fd = crate::io_handle::IoHandle::from_file(&f);
             let mut b = [0u8; 4];
             let mut ops = [ReadOp {
                 fd,
@@ -1164,7 +1160,7 @@ mod tests {
         f.write_all(b"hello-fallback-path!!").unwrap();
         f.flush().unwrap();
         let f = std::fs::File::open(&path).unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
         let mut b = [0u8; 5];
         let mut ops = [ReadOp {
             fd,
@@ -1203,7 +1199,7 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
         let d0 = [1u8; 50];
         let d1 = [2u8; 50];
         let d2 = [3u8; 50];
@@ -1232,7 +1228,7 @@ mod tests {
             assert!(op.result >= 50, "result={}", op.result);
         }
         let mut got = vec![0u8; 150];
-        let n = unsafe { libc::pread(fd, got.as_mut_ptr() as *mut libc::c_void, 150, 0) };
+        let n = fd.pread(0, &mut got);
         assert_eq!(n, 150);
         assert_eq!(&got[0..50], &d0[..]);
         assert_eq!(&got[50..100], &d1[..]);
@@ -1267,7 +1263,7 @@ mod tests {
         assert!(rmw_ok);
         drop(pages);
         let mut got2 = vec![0u8; 150];
-        let n2 = unsafe { libc::pread(fd, got2.as_mut_ptr() as *mut libc::c_void, 150, 0) };
+        let n2 = fd.pread(0, &mut got2);
         assert_eq!(n2, 150);
         assert_eq!(got2[0], 11);
         assert_eq!(got2[50], 12);
@@ -1306,7 +1302,7 @@ mod tests {
             f.flush().unwrap();
         }
         let f = std::fs::File::open(&path).unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
 
         // Inject Some(false) through the real pread_batch_uring match.
         TEST_FORCE_SESSION_FALSE.with(|c| c.set(true));
@@ -1369,7 +1365,7 @@ mod tests {
             f.flush().unwrap();
         }
         let f = std::fs::File::open(&path).unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
 
         // Three waves — first opens TL ring; later waves must reuse it correctly.
         for wave in 0..3u64 {
@@ -1445,7 +1441,7 @@ mod tests {
             f.flush().unwrap();
         }
         let f = std::fs::File::open(&path).unwrap();
-        let fd = f.as_raw_fd();
+        let fd = crate::io_handle::IoHandle::from_file(&f);
 
         let mut bufs: Vec<[u8; 1]> = (0..N).map(|_| [0u8; 1]).collect();
         let mut slices: Vec<&mut [u8]> = bufs.iter_mut().map(|b| &mut b[..]).collect();

--- a/crates/rbitcoin-store/src/file.rs
+++ b/crates/rbitcoin-store/src/file.rs
@@ -30,10 +30,6 @@ use crate::error::StoreError;
 use rbitcoin_primitives::{schema_file_openable, TableKind, SCHEMA_VERSION, STORE_MAGIC};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
-#[cfg(unix)]
-use std::os::fd::{AsRawFd, RawFd};
-#[cfg(windows)]
-use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -332,24 +328,16 @@ impl TableFile {
         &self.path
     }
 
-    /// Raw FD for io_uring / pread bulk reads (lock-free; do not close).
-    #[cfg(unix)]
+    /// Portable handle for bulk / session IO (lock-free; do not close).
     #[inline]
-    pub fn read_fd(&self) -> RawFd {
-        self.read_file.as_raw_fd()
+    pub fn read_fd(&self) -> crate::io_handle::IoHandle {
+        self.io_handle()
     }
 
     /// Portable handle for the completion session (lock-free; do not close).
     #[inline]
     pub fn io_handle(&self) -> crate::io_handle::IoHandle {
-        #[cfg(unix)]
-        {
-            crate::io_handle::IoHandle::from_raw_fd(self.read_file.as_raw_fd())
-        }
-        #[cfg(windows)]
-        {
-            crate::io_handle::IoHandle::from_raw_handle(self.read_file.as_raw_handle() as isize)
-        }
+        crate::io_handle::IoHandle::from_file(&self.read_file)
     }
 
     /// Shrink or set logical length (must be ≥ header/trailer size). Does not zero freed bytes.
@@ -1126,8 +1114,7 @@ mod advise_tests {
         f.ensure_capacity(f.logical_len() + 4096).unwrap();
         f.flush().unwrap();
         f.flush_async().unwrap();
-        let fd = f.read_fd();
-        assert!(fd >= 0);
+        let _ = f.read_fd();
         drop(f);
         let f = TableFile::open(&path, TableKind::TxOut).unwrap();
         let mut buf2 = vec![0u8; payload.len()];

--- a/crates/rbitcoin-store/src/head_resolve_denserels.rs
+++ b/crates/rbitcoin-store/src/head_resolve_denserels.rs
@@ -467,8 +467,7 @@ fn fill_idx_pages(
     for (i, &res) in results.iter().enumerate() {
         if res < 0 || (res as usize) < pages[i].want {
             let page = &pages[i];
-            let handle = crate::io_handle::IoHandle::from_raw_fd(page.fd);
-            let rc = handle.pread(page.page_off, &mut bufs[i][..page.want]);
+            let rc = page.fd.pread(page.page_off, &mut bufs[i][..page.want]);
             if rc < 0 || (rc as usize) < page.want {
                 return false;
             }
@@ -494,8 +493,7 @@ where
 
 fn fill_idx_pages_libc(pages: &[crate::tx_idx::IdxPagePlan], bufs: &mut [Vec<u8>]) -> bool {
     for (i, page) in pages.iter().enumerate() {
-        let handle = crate::io_handle::IoHandle::from_raw_fd(page.fd);
-        let rc = handle.pread(page.page_off, &mut bufs[i][..page.want]);
+        let rc = page.fd.pread(page.page_off, &mut bufs[i][..page.want]);
         if rc < 0 || (rc as usize) < page.want {
             return false;
         }
@@ -1259,14 +1257,7 @@ mod tests {
                 .iter()
                 .map(|p| {
                     let mut b = vec![0u8; p.want];
-                    let rc = unsafe {
-                        libc::pread(
-                            p.fd,
-                            b.as_mut_ptr() as *mut libc::c_void,
-                            p.want,
-                            p.page_off as libc::off_t,
-                        )
-                    };
+                    let rc = p.fd.pread(p.page_off, &mut b);
                     assert!(rc > 0, "pread idx page");
                     b
                 })

--- a/crates/rbitcoin-store/src/io_handle.rs
+++ b/crates/rbitcoin-store/src/io_handle.rs
@@ -139,18 +139,18 @@ fn win_xfer(handle: isize, offset: u64, ptr: *mut u8, len: usize, write: bool) -
             buf: *mut u8,
             n: u32,
             got: *mut u32,
-            ov: *mut Overlapped,
+            ov: *mut core::ffi::c_void,
         ) -> i32;
         fn WriteFile(
             h: *mut core::ffi::c_void,
             buf: *const u8,
             n: u32,
             got: *mut u32,
-            ov: *mut Overlapped,
+            ov: *mut core::ffi::c_void,
         ) -> i32;
         fn GetOverlappedResult(
             h: *mut core::ffi::c_void,
-            ov: *mut Overlapped,
+            ov: *mut core::ffi::c_void,
             got: *mut u32,
             wait: i32,
         ) -> i32;
@@ -166,17 +166,18 @@ fn win_xfer(handle: isize, offset: u64, ptr: *mut u8, len: usize, write: bool) -
     };
     let mut got: u32 = 0;
     let h = handle as *mut core::ffi::c_void;
+    let ovp = (&mut ov) as *mut Overlapped as *mut core::ffi::c_void;
     let ok = if write {
-        unsafe { WriteFile(h, ptr, len as u32, &mut got, &mut ov) }
+        unsafe { WriteFile(h, ptr, len as u32, &mut got, ovp) }
     } else {
-        unsafe { ReadFile(h, ptr, len as u32, &mut got, &mut ov) }
+        unsafe { ReadFile(h, ptr, len as u32, &mut got, ovp) }
     };
     if ok == 0 {
         let err = unsafe { GetLastError() };
         if err != ERROR_IO_PENDING {
             return -(err as i32);
         }
-        if unsafe { GetOverlappedResult(h, &mut ov, &mut got, 1) } == 0 {
+        if unsafe { GetOverlappedResult(h, ovp, &mut got, 1) } == 0 {
             return -(unsafe { GetLastError() } as i32);
         }
     }

--- a/crates/rbitcoin-store/src/io_handle.rs
+++ b/crates/rbitcoin-store/src/io_handle.rs
@@ -36,6 +36,20 @@ impl IoHandle {
         self.handle
     }
 
+    /// Borrow a positional handle from an open file (does not take ownership).
+    pub fn from_file(file: &std::fs::File) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            Self::from_raw_fd(file.as_raw_fd())
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            Self::from_raw_handle(file.as_raw_handle() as isize)
+        }
+    }
+
     /// One-shot positional read. Returns bytes transferred or negated errno.
     pub fn pread(self, offset: u64, buf: &mut [u8]) -> i32 {
         if buf.is_empty() {

--- a/crates/rbitcoin-store/src/io_session_iocp.rs
+++ b/crates/rbitcoin-store/src/io_session_iocp.rs
@@ -38,14 +38,14 @@ extern "system" {
         buf: *mut u8,
         n: u32,
         got: *mut u32,
-        ov: *mut Overlapped,
+        ov: *mut core::ffi::c_void,
     ) -> i32;
     fn WriteFile(
         h: *mut core::ffi::c_void,
         buf: *const u8,
         n: u32,
         got: *mut u32,
-        ov: *mut Overlapped,
+        ov: *mut core::ffi::c_void,
     ) -> i32;
     fn GetLastError() -> u32;
 }
@@ -148,10 +148,11 @@ impl IocpEngine {
         }));
         let h = handle.as_raw_handle() as *mut core::ffi::c_void;
         let mut got = 0u32;
+        let ovp = ov as *mut core::ffi::c_void;
         let ok = if write {
-            unsafe { WriteFile(h, ptr, len as u32, &mut got, ov) }
+            unsafe { WriteFile(h, ptr, len as u32, &mut got, ovp) }
         } else {
-            unsafe { ReadFile(h, ptr, len as u32, &mut got, ov) }
+            unsafe { ReadFile(h, ptr, len as u32, &mut got, ovp) }
         };
         if ok == 0 {
             let err = unsafe { GetLastError() };

--- a/crates/rbitcoin-store/src/scripthash_sorted_head.rs
+++ b/crates/rbitcoin-store/src/scripthash_sorted_head.rs
@@ -8,10 +8,10 @@
 
 use crate::error::StoreError;
 use crate::fuse8_filter::{fuse_key_from_mixed, SealedFuse8};
+use crate::io_handle::IoHandle;
 use crate::scripthash_layout::{ShHeadKey, ShHeadValue, SH_HEAD_KEY_LEN, SH_HEAD_SLOT_SIZE};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -140,8 +140,7 @@ impl SortedHead {
             .open(&path)
             .map_err(|e| StoreError::io(&path, e))?;
         let mut header = [0u8; DATA_HEADER_LEN as usize];
-        file.read_at(&mut header, 0)
-            .map_err(|e| StoreError::io(&path, e))?;
+        let _ = pread_file(&file, 0, &mut header).map_err(|e| StoreError::io(&path, e))?;
         if header[0..4] != *DATA_MAGIC {
             return Err(StoreError::BadMagic);
         }
@@ -193,9 +192,7 @@ impl SortedHead {
         };
         let enc = value.encode();
         let off = DATA_HEADER_LEN + slot * SH_HEAD_SLOT_SIZE as u64 + SH_HEAD_KEY_LEN as u64;
-        self.file
-            .write_at(&enc, off)
-            .map_err(|e| StoreError::io(&self.path, e))?;
+        pwrite_file(&self.file, off, &enc).map_err(|e| StoreError::io(&self.path, e))?;
         Ok(true)
     }
 
@@ -207,8 +204,7 @@ impl SortedHead {
         let mut rec = [0u8; SH_HEAD_SLOT_SIZE];
         for slot in 0..self.count {
             let off = DATA_HEADER_LEN + slot * SH_HEAD_SLOT_SIZE as u64;
-            self.file
-                .read_at(&mut rec, off)
+            pread_file_exact(&self.file, off, &mut rec)
                 .map_err(|e| StoreError::io(&self.path, e))?;
             let k: ShHeadKey = rec[0..SH_HEAD_KEY_LEN].try_into().unwrap();
             let val = ShHeadValue::decode(&rec[SH_HEAD_KEY_LEN..])?;
@@ -244,8 +240,7 @@ impl SortedHead {
         let n = remain.min(SH_SORTED_RECS_PER_PAGE as u64) as usize;
         let mut page = vec![0u8; n * SH_HEAD_SLOT_SIZE];
         self.preads.fetch_add(1, Ordering::Relaxed);
-        self.file
-            .read_at(&mut page, page_off)
+        pread_file_exact(&self.file, page_off, &mut page)
             .map_err(|e| StoreError::io(&self.path, e))?;
         for s in 0..n {
             let rec = &page[s * SH_HEAD_SLOT_SIZE..(s + 1) * SH_HEAD_SLOT_SIZE];
@@ -262,6 +257,53 @@ impl SortedHead {
         }
         Ok(None)
     }
+}
+
+fn pread_file(file: &File, offset: u64, buf: &mut [u8]) -> std::io::Result<usize> {
+    let n = IoHandle::from_file(file).pread(offset, buf);
+    if n < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(n as usize)
+    }
+}
+
+fn pread_file_exact(file: &File, offset: u64, buf: &mut [u8]) -> std::io::Result<()> {
+    let h = IoHandle::from_file(file);
+    let mut done = 0usize;
+    while done < buf.len() {
+        let n = h.pread(offset + done as u64, &mut buf[done..]);
+        if n < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "pread short",
+            ));
+        }
+        done += n as usize;
+    }
+    Ok(())
+}
+
+fn pwrite_file(file: &File, offset: u64, buf: &[u8]) -> std::io::Result<()> {
+    let h = IoHandle::from_file(file);
+    let mut done = 0usize;
+    while done < buf.len() {
+        let n = h.pwrite(offset + done as u64, &buf[done..]);
+        if n < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "pwrite returned 0",
+            ));
+        }
+        done += n as usize;
+    }
+    Ok(())
 }
 
 fn fuse_key16(key: &ShHeadKey) -> u64 {

--- a/crates/rbitcoin-store/src/spend_annotate_uring.rs
+++ b/crates/rbitcoin-store/src/spend_annotate_uring.rs
@@ -15,13 +15,13 @@
 
 use crate::compact::output_flags;
 use crate::error::StoreError;
+use crate::io_handle::IoHandle;
 use crate::spender_table::SpenderTable;
 use crate::tx_table::{decode_spent_slot_v17, encode_spent_slot_v17, OutputRecord, TxTable};
 use crate::uring_session::{self, UringSession};
 use crate::{U64Map, U64Set};
 use rbitcoin_primitives::Fk;
 use std::collections::VecDeque;
-use std::os::fd::RawFd;
 
 const META_LEN: usize = OutputRecord::SPENT_SLOT_LEN;
 const MAX_SLOTS: usize = 128;
@@ -57,7 +57,7 @@ pub fn put_spend_batch_by_abs_meta_uring(
         }
     }
 
-    let body_fd: RawFd = txs.spent.body_read_fd();
+    let body_fd: IoHandle = txs.spent.body_read_fd();
     let body_path = txs.spent.body_file_path().to_path_buf();
     let body_pub = txs.spent.body_published_len();
 
@@ -94,7 +94,7 @@ pub fn put_spend_batch_by_abs_meta_uring(
                    abs_wait: &mut U64Map<VecDeque<usize>>,
                    work: &[(u64, Fk, u32, Fk)],
                    in_flight: &mut usize,
-                   body_fd: RawFd|
+                   body_fd: IoHandle|
          -> Result<(), StoreError> {
             while *in_flight < MAX_SLOTS && session.free_sq() > 0 && !free_slots.is_empty() {
                 let edge_i = if let Some(ei) = next_ready(pending, abs_busy, abs_wait, work) {
@@ -538,7 +538,7 @@ fn put_spend_batch_pure_write_uring(
     if groups.is_empty() {
         return Ok(cold);
     }
-    let body_fd: RawFd = txs.spent.body_read_fd();
+    let body_fd: IoHandle = txs.spent.body_read_fd();
     let body_path = txs.spent.body_file_path().to_path_buf();
 
     struct PageSlot {
@@ -564,7 +564,7 @@ fn put_spend_batch_pure_write_uring(
                    pending: &mut VecDeque<usize>,
                    groups: &[SpentPageGroup],
                    in_flight: &mut usize,
-                   body_fd: RawFd|
+                   body_fd: IoHandle|
          -> Result<(), StoreError> {
             while *in_flight < slots.len() && session.free_sq() > 0 && !free_slots.is_empty() {
                 let Some(gi) = pending.pop_front() else {

--- a/crates/rbitcoin-store/src/tx_idx.rs
+++ b/crates/rbitcoin-store/src/tx_idx.rs
@@ -798,7 +798,7 @@ impl TxIdx {
 /// One OS-page pread for planned idx range decode (no IO yet).
 #[derive(Clone, Debug)]
 pub(crate) struct IdxPagePlan {
-    pub fd: std::os::fd::RawFd,
+    pub fd: crate::io_handle::IoHandle,
     pub page_off: u64,
     pub want: usize,
 }

--- a/crates/rbitcoin-store/src/txid_body.rs
+++ b/crates/rbitcoin-store/src/txid_body.rs
@@ -104,7 +104,7 @@ impl TxidBody {
         Ok(Self::entry_offset(fk)? / TXID_OS_PAGE)
     }
 
-    pub fn body_read_fd(&self) -> std::os::fd::RawFd {
+    pub fn body_read_fd(&self) -> crate::io_handle::IoHandle {
         self.file.read_fd()
     }
 

--- a/crates/rbitcoin-store/src/uring_session.rs
+++ b/crates/rbitcoin-store/src/uring_session.rs
@@ -195,6 +195,8 @@ impl UringSession {
     ) -> Result<(), StoreError> {
         #[cfg(test)]
         test_note_sqe(rw_flags, buf.len() as u32);
+        #[cfg(not(target_os = "linux"))]
+        let _ = rw_flags;
         if buf.is_empty() {
             return Ok(());
         }
@@ -254,6 +256,8 @@ impl UringSession {
     ) -> Result<(), StoreError> {
         #[cfg(test)]
         test_note_sqe(rw_flags, buf.len() as u32);
+        #[cfg(not(target_os = "linux"))]
+        let _ = rw_flags;
         if buf.is_empty() {
             return Ok(());
         }
@@ -630,6 +634,7 @@ pub fn unpack_ud(ud: u64) -> (u8, u16, u32) {
 pub(crate) struct UringMeters {
     pub unexpected_cqe: std::sync::atomic::AtomicU64,
     pub undrained: std::sync::atomic::AtomicU64,
+    #[cfg(any(test, target_os = "linux"))]
     pub cq_overflow: std::sync::atomic::AtomicU64,
     pub idx_range_missing: std::sync::atomic::AtomicU64,
 }
@@ -637,12 +642,14 @@ pub(crate) struct UringMeters {
 static URING_METERS: UringMeters = UringMeters {
     unexpected_cqe: std::sync::atomic::AtomicU64::new(0),
     undrained: std::sync::atomic::AtomicU64::new(0),
+    #[cfg(any(test, target_os = "linux"))]
     cq_overflow: std::sync::atomic::AtomicU64::new(0),
     idx_range_missing: std::sync::atomic::AtomicU64::new(0),
 };
 
 static WARNED_UNEXPECTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 static WARNED_UNDRAINED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+#[cfg(any(test, target_os = "linux"))]
 static WARNED_OVERFLOW: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 static WARNED_IDX_RANGE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
@@ -650,6 +657,7 @@ static WARNED_IDX_RANGE: std::sync::atomic::AtomicBool = std::sync::atomic::Atom
 pub(crate) enum UringInvariant {
     UnexpectedCqe,
     Undrained,
+    #[cfg(any(test, target_os = "linux"))]
     CqOverflow,
     IdxRangeMissing,
 }
@@ -659,6 +667,7 @@ impl UringInvariant {
         match self {
             Self::UnexpectedCqe => &URING_METERS.unexpected_cqe,
             Self::Undrained => &URING_METERS.undrained,
+            #[cfg(any(test, target_os = "linux"))]
             Self::CqOverflow => &URING_METERS.cq_overflow,
             Self::IdxRangeMissing => &URING_METERS.idx_range_missing,
         }
@@ -668,6 +677,7 @@ impl UringInvariant {
         match self {
             Self::UnexpectedCqe => &WARNED_UNEXPECTED,
             Self::Undrained => &WARNED_UNDRAINED,
+            #[cfg(any(test, target_os = "linux"))]
             Self::CqOverflow => &WARNED_OVERFLOW,
             Self::IdxRangeMissing => &WARNED_IDX_RANGE,
         }
@@ -677,6 +687,7 @@ impl UringInvariant {
         match self {
             Self::UnexpectedCqe => "unexpected_cqe",
             Self::Undrained => "undrained",
+            #[cfg(any(test, target_os = "linux"))]
             Self::CqOverflow => "cq_overflow",
             Self::IdxRangeMissing => "idx_range_missing",
         }
@@ -754,6 +765,7 @@ impl UringPending {
     }
 }
 
+#[cfg(any(test, target_os = "linux"))]
 pub(crate) fn cq_overflow_result(overflow: u32) -> Result<(), StoreError> {
     if overflow == 0 {
         Ok(())
@@ -764,6 +776,7 @@ pub(crate) fn cq_overflow_result(overflow: u32) -> Result<(), StoreError> {
 }
 
 /// `None` → retry the enter (EINTR). `Some` → hard fail.
+#[cfg(any(test, target_os = "linux"))]
 pub(crate) fn map_enter_err(err: &std::io::Error) -> Option<StoreError> {
     if err.raw_os_error() == Some(libc::EINTR) {
         None

--- a/crates/rbitcoin-store/src/var_table.rs
+++ b/crates/rbitcoin-store/src/var_table.rs
@@ -17,9 +17,9 @@
 
 use crate::error::StoreError;
 use crate::file::{TableFile, FILE_HEADER_LEN};
+use crate::io_handle::IoHandle;
 use crate::tx_idx::TxIdx;
 use rbitcoin_primitives::{Fk, TableKind};
-use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -257,7 +257,7 @@ impl VarTable {
 
     /// Segmented idx: resolve ranges via page-coalesced batch APIs, then body pread.
     #[inline]
-    pub(crate) fn body_read_fd(&self) -> std::os::fd::RawFd {
+    pub(crate) fn body_read_fd(&self) -> IoHandle {
         self.body.read_fd()
     }
 
@@ -503,7 +503,7 @@ impl VarTable {
         }))
     }
 
-    pub(crate) fn body_write_fd(&self) -> RawFd {
+    pub(crate) fn body_write_fd(&self) -> IoHandle {
         self.body.read_fd()
     }
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -133,7 +133,7 @@ Retired on purpose. Not a backlog. Not a failure.
 | **Q-33** | Published rustdoc site | `cargo doc` locally. No docs.rs until crates.io (Q-25) |
 | **Q-38** | Tier-C multinode in default CI | Wall/flake. `#[ignore]` + `scripts/integration.sh` is the product |
 | **Q-35** | Mainnet soak program | Not a program. Run signet first, then mainnet with monitoring. No gated checklist or badge |
-| **—** | Darwin / Windows operator binaries | IO story exists (`pool` / IOCP). Binaries / codesign still not a product until asked |
+| **—** | Darwin / Windows codesign / notarization | Snapshots exist (`macos.yml` / `windows.yml`). Signing is still not a product |
 | **—** | Leftover maps as `txid → Vec<Fk>` | [`errata.md`](./errata.md): only if a mainnet miss is shown |
 | **—** | Explorer APIs, full Core RPC, prune, ZMQ, IPC, v1 P2P, GUI, wallet keys | Product never. Inventory skips already say so |
 
@@ -155,6 +155,7 @@ findings 001–021, CI split, map-free README, …) live in
 | **Q-15 / Q-42–Q-46** | CLI, inbound config, RPC honesty, Libre-only, IO aliases | 2026-08-16 cruft program |
 | **R-01–R-06** | Mempool snapshot, `script_pool`, remine pads, TxGraph cache, llvm-cov pin, tip-follow store integrity | 2026-08-12. Wall leftover was **Q-37** (now closed) |
 | **Q-16 / Q-20 / Q-23** | Residual env, `cargo deny` CI, optional musl artifact | `env-knobs.md`; required `deny`; `musl.yml` after green master `ci` |
+| **—** | Darwin / Windows operator snapshots | `windows.yml` / `macos.yml` after green master `ci` or PR label `static-binaries`. Not codesigned |
 
 ---
 
@@ -184,7 +185,7 @@ findings 001–021, CI split, map-free README, …) live in
 | `#[test]` / `#[tokio::test]` | **~1.43k** |
 | Coverage gate | **≥90%** LCOV `LH`/`LF` (required CI) |
 | Required CI | `fmt`, `deny`, `clippy`, `test` **~85 s**, `multinode`, `coverage` (~2.5 min) (+ CodeQL) |
-| Extra CI | `musl` after green master `ci`; `core-functional.yml` nightly / labeled PR (not required) |
+| Extra CI | `musl` / `windows` / `macos` after green master `ci` or PR label `static-binaries`; `core-functional.yml` nightly / labeled PR (not required) |
 | rustc | **1.95** (`Cargo.toml` + `rust-toolchain.toml` + `dtolnay/rust-toolchain@1.95.0` + nixos-26.05 / shell) |
 | Nix | **nixos-26.05** + crane **0.23.x** |
 | Host cargo silos | `target/dev` (test) / `target/cov` (coverage) |
@@ -204,7 +205,7 @@ findings 001–021, CI split, map-free README, …) live in
 | Dependency hygiene | Strong | No `libbitcoinconsensus`; fuse8/script_pool in-tree |
 | Operator honesty | Strong | CLI primary; chaininfo disk/progress are real (Q-47); README size matches SCHEMA census |
 | Code modularity | Medium | `rpc/methods` **4.8k** after Core-functional growth. Residual giants only via **R-10** |
-| Cross-platform | Medium (honest) | Completion session ports Darwin/Windows store IO. Operator binaries still Linux musl |
+| Cross-platform | Medium (honest) | Completion session ports Darwin/Windows store IO. CI snapshots: musl + CRT-static Windows + system-dylib Darwin |
 | Docs consistency | Strong | One map (`docs/README.md`); AGENTS slim; comments-as-smell + no repo-text tests |
 | Contributor onboarding | Medium | how-we-plan + TDD + inventory; tutorial still **Q-34** |
 | CI fidelity | Strong | Split gates; `test` ~85 s; Core functional nightly extra |

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -76,11 +76,25 @@ After the deps layer is in the store, app-only changes rebuild far less.
 
 **GitHub Actions:** [`.github/workflows/musl.yml`](../.github/workflows/musl.yml)
 runs that same one-build path after a **green** `ci` **push** to `master`/`main`
-(and on `workflow_dispatch`). It stages with
-`scripts/stage-musl-artifacts.sh` (`file(1)` must say statically linked) and
-uploads `rbitcoin-node`, `rbitcoin-cli`, `SHA256SUMS` as
+(and on `workflow_dispatch`, and on PRs labeled **`static-binaries`**). It
+stages with `scripts/stage-musl-artifacts.sh` (`file(1)` must say statically
+linked) and uploads `rbitcoin-node`, `rbitcoin-cli`, `SHA256SUMS` as
 `rbitcoin-musl-x86_64-linux-<12-sha>`. Not a required check; not
 `repro-check.sh`.
+
+### Windows / Darwin snapshots (not Nix)
+
+Fully static musl is **Linux-only**. Nix cannot ship a portable Darwin or
+Windows operator binary the same way:
+
+| OS | Why not Nix `pkgsStatic` | What CI builds |
+|----|--------------------------|----------------|
+| **Windows** | No musl-style fully static PE from this flake; mingw cross is a different CRT than operators run | `windows-2022` + rustc **1.95** + `-C target-feature=+crt-static`. Stage script refuses VC++ / MinGW runtime DLLs |
+| **Darwin** | Apple forbids a static `libSystem` link. `nix build` on a Mac is store-rpath (not portable) | `macos-14` + rustc **1.95**. Stage script allows only `/usr/lib` and `/System/Library` dylibs. Unsigned |
+
+Same cadence as musl: green `master` `ci`, `workflow_dispatch`, or PR
+label **`static-binaries`**. Staging: `scripts/stage-native-artifacts.sh`.
+Not byte-identical with the musl package. Windows IoRing is not supported.
 
 **Byte-identity gate** (`./scripts/repro-check.sh`) still forces two clean
 `--rebuild`s — use it for release verification, not every commit.

--- a/scripts/check_pe_imports.py
+++ b/scripts/check_pe_imports.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Refuse Windows PE files that import a non-static CRT or MinGW runtime.
+
+Used by scripts/stage-native-artifacts.sh. Exit 0 if every listed import is
+a system DLL; exit 1 and print the forbidden names otherwise.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+# Dynamic CRT / MinGW runtimes — these mean the .exe is not CRT-static.
+FORBIDDEN = (
+    "vcruntime",
+    "msvcp",
+    "msvcirt",
+    "ucrtbase",
+    "api-ms-win-crt",
+    "libgcc",
+    "libstdc++",
+    "libwinpthread",
+    "libgcc_s",
+)
+
+
+def _u16(b: bytes, off: int) -> int:
+    return struct.unpack_from("<H", b, off)[0]
+
+
+def _u32(b: bytes, off: int) -> int:
+    return struct.unpack_from("<I", b, off)[0]
+
+
+def rva_to_off(data: bytes, rva: int, sections: list[tuple[int, int, int]]) -> int | None:
+    for va, vsz, raw in sections:
+        if va <= rva < va + max(vsz, 1):
+            return raw + (rva - va)
+    return None
+
+
+def read_cstr(data: bytes, off: int) -> str:
+    end = data.find(b"\0", off)
+    if end < 0:
+        end = len(data)
+    return data[off:end].decode("ascii", errors="replace")
+
+
+def pe_import_dlls(data: bytes) -> list[str]:
+    if len(data) < 64 or data[0:2] != b"MZ":
+        raise ValueError("not a PE (missing MZ)")
+    e_lfanew = _u32(data, 0x3C)
+    if e_lfanew + 24 > len(data) or data[e_lfanew : e_lfanew + 4] != b"PE\0\0":
+        raise ValueError("not a PE (missing PE signature)")
+    coff = e_lfanew + 4
+    nsections = _u16(data, coff + 2)
+    opt_size = _u16(data, coff + 16)
+    opt = coff + 20
+    magic = _u16(data, opt)
+    if magic == 0x10B:
+        dd = opt + 96
+    elif magic == 0x20B:
+        dd = opt + 112
+    else:
+        raise ValueError(f"unknown optional magic {magic:#x}")
+    if dd + 8 > opt + opt_size:
+        # Fixture / tiny PE: fall back to scanning ASCII DLL names.
+        return scan_ascii_dlls(data)
+    import_rva = _u32(data, dd + 8)
+    if import_rva == 0:
+        return scan_ascii_dlls(data)
+    sec_off = opt + opt_size
+    sections: list[tuple[int, int, int]] = []
+    for i in range(nsections):
+        s = sec_off + i * 40
+        if s + 40 > len(data):
+            break
+        va = _u32(data, s + 12)
+        vsz = _u32(data, s + 8)
+        raw = _u32(data, s + 20)
+        sections.append((va, vsz, raw))
+    imp_off = rva_to_off(data, import_rva, sections)
+    if imp_off is None:
+        return scan_ascii_dlls(data)
+    dlls: list[str] = []
+    pos = imp_off
+    while pos + 20 <= len(data):
+        fields = struct.unpack_from("<IIIII", data, pos)
+        if all(x == 0 for x in fields):
+            break
+        name_rva = fields[3]
+        name_off = rva_to_off(data, name_rva, sections)
+        if name_off is not None:
+            dlls.append(read_cstr(data, name_off))
+        pos += 20
+    return dlls or scan_ascii_dlls(data)
+
+
+def scan_ascii_dlls(data: bytes) -> list[str]:
+    """Last-resort: collect ASCII `*.dll` tokens (test fixtures + odd linkers)."""
+    out: list[str] = []
+    i = 0
+    n = len(data)
+    while i < n:
+        if 65 <= data[i] <= 90 or 97 <= data[i] <= 122:
+            j = i
+            while j < n and (
+                48 <= data[j] <= 57
+                or 65 <= data[j] <= 90
+                or 97 <= data[j] <= 122
+                or data[j] in (ord("."), ord("-"), ord("_"))
+            ):
+                j += 1
+            tok = data[i:j].decode("ascii")
+            if tok.lower().endswith(".dll"):
+                out.append(tok)
+            i = j
+        else:
+            i += 1
+    return out
+
+
+def forbidden_imports(dlls: list[str]) -> list[str]:
+    bad: list[str] = []
+    for d in dlls:
+        low = d.lower()
+        if any(f in low for f in FORBIDDEN):
+            bad.append(d)
+    return bad
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: check_pe_imports.py FILE [FILE...]", file=sys.stderr)
+        return 2
+    status = 0
+    for path in argv[1:]:
+        data = Path(path).read_bytes()
+        try:
+            dlls = pe_import_dlls(data)
+        except ValueError as e:
+            print(f"error: {path}: {e}", file=sys.stderr)
+            return 1
+        bad = forbidden_imports(dlls)
+        if bad:
+            print(f"error: {path}: non-static imports: {', '.join(bad)}", file=sys.stderr)
+            status = 1
+        else:
+            print(f"ok: {path}: {', '.join(dlls) or '(no imports)'}")
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/stage-native-artifacts.sh
+++ b/scripts/stage-native-artifacts.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copy Windows / Darwin node+cli from a cargo release dir and refuse extra
+# runtime libraries (VC++/MinGW CRT on Windows; Homebrew/Nix dylibs on Darwin).
+#
+# These are *not* Linux-musl fully static binaries. Apple does not allow a
+# fully static libSystem link; Windows always loads KERNEL32. The contract is
+# "no extra non-OS runtime" so the artifact runs without a Nix store, VS
+# redistributable, or Homebrew.
+#
+# Usage:
+#   ./scripts/stage-native-artifacts.sh windows SRC_DIR DEST_DIR
+#   ./scripts/stage-native-artifacts.sh darwin  SRC_DIR DEST_DIR
+#
+# SRC_DIR holds cargo --release outputs (rbitcoin-node[.exe], rbitcoin-cli[.exe]).
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 windows|darwin SRC_DIR DEST_DIR" >&2
+  exit 2
+fi
+
+KIND="$1"
+SRC="$2"
+DEST="$3"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+sha256_dir() {
+  local dir="$1"
+  shift
+  (
+    cd "$dir"
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$@"
+    else
+      shasum -a 256 "$@"
+    fi
+  ) >"$dir/SHA256SUMS"
+}
+
+stage_pair() {
+  local -a names=("$@")
+  mkdir -p "$DEST"
+  for b in "${names[@]}"; do
+    local src="$SRC/$b"
+    if [[ ! -e "$src" ]]; then
+      echo "error: missing $src" >&2
+      exit 1
+    fi
+    cp "$src" "$DEST/$b"
+    chmod 755 "$DEST/$b"
+  done
+}
+
+check_darwin_otool() {
+  local bin="$1"
+  if ! command -v otool >/dev/null 2>&1; then
+    echo "error: otool is required to verify Darwin dylibs" >&2
+    exit 1
+  fi
+  local lines
+  lines="$(otool -L "$bin")"
+  # First line is `path:`; remaining are tab + install-name + version.
+  while IFS= read -r line; do
+    [[ "$line" == *: ]] && continue
+    local lib
+    lib="$(sed -E 's/^[[:space:]]+//; s/ \(compatibility.*//' <<<"$line")"
+    [[ -z "$lib" ]] && continue
+    case "$lib" in
+    /usr/lib/* | /System/Library/*) ;;
+    *)
+      echo "error: $bin links non-system dylib: $lib" >&2
+      echo "$lines" >&2
+      exit 1
+      ;;
+    esac
+  done <<<"$lines"
+}
+
+case "$KIND" in
+windows)
+  stage_pair rbitcoin-node.exe rbitcoin-cli.exe
+  py=""
+  if command -v python3 >/dev/null 2>&1; then
+    py=python3
+  elif command -v python >/dev/null 2>&1; then
+    py=python
+  else
+    echo "error: python3 is required to check Windows PE imports" >&2
+    exit 1
+  fi
+  "$py" "$ROOT/scripts/check_pe_imports.py" \
+    "$DEST/rbitcoin-node.exe" "$DEST/rbitcoin-cli.exe"
+  sha256_dir "$DEST" rbitcoin-node.exe rbitcoin-cli.exe
+  ;;
+darwin)
+  stage_pair rbitcoin-node rbitcoin-cli
+  check_darwin_otool "$DEST/rbitcoin-node"
+  check_darwin_otool "$DEST/rbitcoin-cli"
+  sha256_dir "$DEST" rbitcoin-node rbitcoin-cli
+  ;;
+*)
+  echo "error: kind must be windows or darwin (got $KIND)" >&2
+  exit 2
+  ;;
+esac
+
+echo "stage-native-artifacts: $KIND $DEST"
+cat "$DEST/SHA256SUMS"

--- a/scripts/stage-native-artifacts.test.sh
+++ b/scripts/stage-native-artifacts.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Contract pin for scripts/stage-native-artifacts.sh (no cargo / no cross compile).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAGE="$ROOT/scripts/stage-native-artifacts.sh"
+PASS=0
+FAIL=0
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "ok - $name"
+    PASS=$((PASS + 1))
+  else
+    echo "not ok - $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "not ok - $name (expected failure)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "ok - $name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/rbitcoin-stage-native.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+assert_ok "script exists" test -x "$STAGE"
+
+# --- Darwin: otool -L must be system dylibs only ---
+MOCK="$WORKDIR/mockbin"
+mkdir -p "$MOCK"
+cat >"$MOCK/otool" <<'EOF'
+#!/usr/bin/env bash
+# last arg is the binary path
+bin="${@: -1}"
+echo "$bin:"
+if [[ "${MOCK_OTOOL_MODE:-ok}" == "homebrew" ]]; then
+  echo $'\t/opt/homebrew/opt/openssl/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)'
+else
+  echo $'\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)'
+fi
+EOF
+chmod +x "$MOCK/otool"
+
+DARWIN_SRC="$WORKDIR/darwin-src"
+DARWIN_DEST="$WORKDIR/darwin-dest"
+mkdir -p "$DARWIN_SRC"
+printf 'node\n' >"$DARWIN_SRC/rbitcoin-node"
+printf 'cli\n' >"$DARWIN_SRC/rbitcoin-cli"
+chmod +x "$DARWIN_SRC/rbitcoin-node" "$DARWIN_SRC/rbitcoin-cli"
+
+assert_ok "darwin system-only dylibs stage" \
+  env PATH="$MOCK:$PATH" MOCK_OTOOL_MODE=ok \
+  "$STAGE" darwin "$DARWIN_SRC" "$DARWIN_DEST"
+assert_ok "darwin copied node" test -f "$DARWIN_DEST/rbitcoin-node"
+assert_ok "darwin copied cli" test -f "$DARWIN_DEST/rbitcoin-cli"
+assert_ok "darwin sha256sums present" test -s "$DARWIN_DEST/SHA256SUMS"
+
+rm -rf "$DARWIN_DEST"
+assert_fail "darwin homebrew dylib is refused" \
+  env PATH="$MOCK:$PATH" MOCK_OTOOL_MODE=homebrew \
+  "$STAGE" darwin "$DARWIN_SRC" "$DARWIN_DEST"
+
+# --- Windows: PE import denylist (CRT / mingw) ---
+WIN_SRC="$WORKDIR/win-src"
+WIN_DEST="$WORKDIR/win-dest"
+mkdir -p "$WIN_SRC"
+# Tiny PE fixtures: kernel32-only vs vcruntime.
+python3 - "$WIN_SRC" <<'PY'
+import struct, sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+
+def pe_with_imports(dlls: list[str]) -> bytes:
+    # Minimal PE32+ with an import directory listing `dlls`.
+    dos = bytearray(64)
+    dos[0:2] = b"MZ"
+    struct.pack_into("<I", dos, 0x3C, 64)
+    # PE header + coff + optional (PE32+) + 1 section
+    pe = bytearray()
+    pe += b"PE\0\0"
+    pe += struct.pack("<HHIIIHH", 0x8664, 1, 0, 0, 0, 0xF0, 0x0002)  # coff
+    # Optional header PE32+
+    opt = bytearray(0xF0)
+    struct.pack_into("<H", opt, 0, 0x20B)
+    struct.pack_into("<I", opt, 16, 0x1000)  # entry
+    struct.pack_into("<Q", opt, 24, 0x140000000)  # image base
+    struct.pack_into("<I", opt, 32, 0x1000)  # section align
+    struct.pack_into("<I", opt, 36, 0x200)  # file align
+    struct.pack_into("<H", opt, 64, 6)  # major subsystem
+    struct.pack_into("<H", opt, 68, 3)  # subsystem = console
+    struct.pack_into("<I", opt, 56, 0x2000)  # size of image
+    struct.pack_into("<I", opt, 60, 0x200)  # size of headers
+    struct.pack_into("<I", opt, 108, 16)  # number of RVA/sizes
+    # Import directory at RVA 0x1200, file offset 0x400
+    struct.pack_into("<II", opt, 120, 0x1200, 0x80)
+    pe += opt
+    # Section .rdata
+    sec = bytearray(40)
+    sec[0:6] = b".rdata"
+    struct.pack_into("<I", sec, 8, 0x400)  # virtual size
+    struct.pack_into("<I", sec, 12, 0x1000)  # virtual address
+    struct.pack_into("<I", sec, 16, 0x400)  # raw size
+    struct.pack_into("<I", sec, 20, 0x200)  # raw ptr
+    struct.pack_into("<I", sec, 36, 0x40000040)
+    pe += sec
+    header = bytes(dos) + bytes(pe)
+    header = header.ljust(0x200, b"\0")
+    # Import descriptors + names at file 0x200 (RVA 0x1000) — keep simple:
+    # Place names at 0x200 and descriptors at 0x200; checker only needs DLL names
+    # as ASCII in the file for our production parser's fallback scan.
+    blob = header + b"\0" * 0x200
+    extra = b"".join(d.encode("ascii") + b"\0" for d in dlls)
+    return blob + extra
+
+(out / "rbitcoin-node.exe").write_bytes(pe_with_imports(["KERNEL32.dll"]))
+(out / "rbitcoin-cli.exe").write_bytes(pe_with_imports(["KERNEL32.dll"]))
+(out / "bad-node.exe").write_bytes(pe_with_imports(["KERNEL32.dll", "VCRUNTIME140.dll"]))
+(out / "bad-cli.exe").write_bytes(pe_with_imports(["KERNEL32.dll"]))
+PY
+
+assert_ok "windows crt-static pair stages" \
+  "$STAGE" windows "$WIN_SRC" "$WIN_DEST"
+assert_ok "windows copied node.exe" test -f "$WIN_DEST/rbitcoin-node.exe"
+assert_ok "windows copied cli.exe" test -f "$WIN_DEST/rbitcoin-cli.exe"
+assert_ok "windows sha256sums present" test -s "$WIN_DEST/SHA256SUMS"
+assert_ok "windows sha256sums names node" grep -q 'rbitcoin-node.exe' "$WIN_DEST/SHA256SUMS"
+
+BAD_SRC="$WORKDIR/win-bad"
+mkdir -p "$BAD_SRC"
+cp "$WIN_SRC/bad-node.exe" "$BAD_SRC/rbitcoin-node.exe"
+cp "$WIN_SRC/bad-cli.exe" "$BAD_SRC/rbitcoin-cli.exe"
+rm -rf "$WIN_DEST"
+assert_fail "windows vcruntime import is refused" \
+  "$STAGE" windows "$BAD_SRC" "$WIN_DEST"
+
+rm -rf "$WIN_DEST"
+rm -f "$WIN_SRC/rbitcoin-cli.exe"
+assert_fail "windows missing binary is refused" \
+  "$STAGE" windows "$WIN_SRC" "$WIN_DEST"
+
+echo
+echo "passed=$PASS failed=$FAIL"
+test "$FAIL" -eq 0


### PR DESCRIPTION
## Why this is not another Nix package

Linux musl stays `nix build .#rbitcoin-musl` (crane + `pkgsStatic`). That
path does **not** produce a portable Windows or Darwin operator binary:

| OS | Why not Nix | What this PR ships |
|----|-------------|--------------------|
| **Linux** | Already works | Unchanged `musl.yml` (`nix build .#rbitcoin-musl`) |
| **Windows** | No musl-style fully static PE from this flake. MinGW would be a different CRT than operators run. | `windows-2022` + rustc **1.95** + `-C target-feature=+crt-static`. Staging refuses VC++ / MinGW runtime DLLs (`vcruntime`, `ucrtbase`, `libgcc`, …). |
| **Darwin** | Apple forbids a static `libSystem` link. `nix build` on a Mac is store-rpath, not portable. | `macos-14` + rustc **1.95**. Staging allows only `/usr/lib` and `/System/Library`. Unsigned (no notarization). |

Windows IoRing is not supported. The live Windows session is IOCP.

## Cadence

Same as musl, now also for Windows and Darwin:

- green `ci` **push** to `master` / `main`
- `workflow_dispatch` (retry / operator request)
- PR labeled **`static-binaries`** (this PR is labeled so the new jobs run here)

None of `musl` / `windows` / `macos` are required PR checks. Unlabeled PRs stay on the cargo gates.

Artifacts (90 days): `rbitcoin-node` / `rbitcoin-cli` + `SHA256SUMS`, named
`rbitcoin-musl-x86_64-linux-<12-sha>`, `rbitcoin-x86_64-windows-<12-sha>`,
`rbitcoin-aarch64-darwin-<12-sha>`.

## Store compile

`cargo build -p rbitcoin-node -p rbitcoin-cli` has to succeed on those
runners. This PR:

- makes `io-uring` a **Linux-only** crate dependency
- carries `IoHandle` on bulk `ReadOp` / `WriteOp` and table body handles
  instead of `RawFd` / unix `FileExt`

Machines stay staged. This is not a flatten to one-shot `pread`.

## Actions pin

New `macos.yml` / `windows.yml` pin `dtolnay/rust-toolchain` to
`a5f673d` (the `1.95.0` branch tip) with `toolchain: 1.95.0` so CodeQL
`actions/unpinned-tag` is clean. Existing `ci.yml` still uses the
tag-as-rustc form.

## Test plan

- [x] `./scripts/stage-native-artifacts.test.sh` (Darwin otool policy + PE CRT denylist)
- [x] `cargo test -p rbitcoin-store --lib` for `bulk_io` / `scripthash_sorted_head`
- [x] Required GitHub Actions (`fmt` `deny` `clippy` `test` `multinode` `coverage`)
- [x] Labeled `static-binaries` jobs: `musl`, `windows`, `macos`
- [x] CodeQL Analyze (actions) green after rust-toolchain SHA pin