### PR TITLE
ci: install nightly miri instead of asking 1.95 for it

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -29,10 +29,13 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
-        with:
-          toolchain: nightly
-          components: miri, rust-src
+      # a5f673d0 is the 1.95.0 action snapshot (CodeQL SHA). It has no
+      # `toolchain` input — `with: toolchain: nightly` is ignored and
+      # `components: miri` then fails (`miri` is not a 1.95 component).
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
+
+      - name: rustup nightly + miri
+        run: rustup toolchain install nightly --component miri --component rust-src --profile minimal --allow-downgrade --no-self-update
 
       - name: cargo miri test -p rbitcoin-primitives
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ before 1.0).
 
 ### Changed
 
+- **Nightly Miri installs nightly:** `miri.yml` asked the CodeQL-pinned
+  1.95.0 `dtolnay/rust-toolchain` snapshot for `components: miri` (that
+  action has no `toolchain` input). First scheduled run died in 9s.
+  Nightly + miri is a `rustup` step; product rustc stays 1.95.
+
 - **IBD exits to tip follow at the peer horizon:** leftover off-path
   `getdata` is dropped so catch-up can complete; if peers then advertise
   a higher tip (`lag > 2`), `headers_done` unlatches and `getheaders`


### PR DESCRIPTION
dtolnay/rust-toolchain@a5f673d0 is the 1.95.0 snapshot and has no toolchain input, so with: toolchain: nightly was ignored and components: miri failed the first scheduled run in 9s.