### PR TITLE
ci: Node 24 actions and real nightly rust-toolchain pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
         with:
-          toolchain: 1.95.0
           targets: x86_64-pc-windows-msvc
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -156,8 +155,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
-        with:
-          toolchain: 1.95.0
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ci-macos

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,9 +34,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -49,7 +48,7 @@ jobs:
           tool: cargo-fuzz@0.13.2
 
       # rust-toolchain.toml is 1.95; cargo-fuzz needs nightly -Zsanitizer.
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -64,7 +63,7 @@ jobs:
 
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -80,9 +79,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -97,7 +95,7 @@ jobs:
           shared-key: fuzz-v2-contents
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -122,9 +120,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -134,7 +131,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -144,7 +141,7 @@ jobs:
           shared-key: fuzz-v2-session
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -169,9 +166,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -181,7 +177,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -191,7 +187,7 @@ jobs:
           shared-key: fuzz-cmpct-differential
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -216,9 +212,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -228,7 +223,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -238,7 +233,7 @@ jobs:
           shared-key: fuzz-block-differential
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -263,9 +258,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -275,7 +269,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -285,7 +279,7 @@ jobs:
           shared-key: fuzz-block-spend
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -310,9 +304,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -322,7 +315,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -332,7 +325,7 @@ jobs:
           shared-key: fuzz-script-differential
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -357,9 +350,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -369,7 +361,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -379,7 +371,7 @@ jobs:
           shared-key: fuzz-block-fork
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -404,9 +396,8 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
 
       - name: clang (libFuzzer)
@@ -416,7 +407,7 @@ jobs:
         with:
           tool: cargo-fuzz@0.13.2
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -426,7 +417,7 @@ jobs:
           shared-key: fuzz-cmpct-reorg
           workspaces: "fuzz -> fuzz/target"
 
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -440,7 +431,7 @@ jobs:
 
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -458,16 +449,15 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
       - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-fuzz@0.13.2
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -475,7 +465,7 @@ jobs:
         with:
           shared-key: fuzz-block-reorg-n
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -487,7 +477,7 @@ jobs:
         run: ./scripts/fuzz-run.sh block_reorg_n_differential
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -505,16 +495,15 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
       - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-fuzz@0.13.2
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -522,7 +511,7 @@ jobs:
         with:
           shared-key: fuzz-block-csv
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -534,7 +523,7 @@ jobs:
         run: ./scripts/fuzz-run.sh block_csv_differential
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -552,16 +541,15 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
       - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-fuzz@0.13.2
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -569,7 +557,7 @@ jobs:
         with:
           shared-key: fuzz-mempool
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -581,7 +569,7 @@ jobs:
         run: ./scripts/fuzz-run.sh mempool_differential
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -599,16 +587,15 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
       - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-fuzz@0.13.2
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/rbitcoin/core-bitcoind
           key: core-bitcoind-v31.1-${{ runner.os }}-${{ runner.arch }}
@@ -616,7 +603,7 @@ jobs:
         with:
           shared-key: fuzz-script-verify
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -628,7 +615,7 @@ jobs:
         run: ./scripts/fuzz-run.sh script_verify_differential
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -643,9 +630,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
@@ -656,7 +642,7 @@ jobs:
         with:
           shared-key: fuzz-addrv2
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -669,7 +655,7 @@ jobs:
         run: ./scripts/fuzz-run.sh addrv2_wire
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -684,9 +670,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
@@ -697,7 +682,7 @@ jobs:
         with:
           shared-key: fuzz-inv-getdata
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -710,7 +695,7 @@ jobs:
         run: ./scripts/fuzz-run.sh inv_getdata_wire
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/
@@ -725,9 +710,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b
+      - uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly
         with:
-          toolchain: nightly
           components: rust-src
       - name: clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
@@ -738,7 +722,7 @@ jobs:
         with:
           shared-key: fuzz-electrum-json
           workspaces: "fuzz -> fuzz/target"
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: fuzz/corpus
           key: fuzz-corpus-${{ github.job }}-${{ github.run_id }}
@@ -751,7 +735,7 @@ jobs:
         run: ./scripts/fuzz-run.sh electrum_json
       - name: upload crashers
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ github.job }}
           path: fuzz/crashers/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
         with:
-          toolchain: 1.95.0
           targets: x86_64-pc-windows-msvc
 
       # No build cache: cached objects must not feed shipped binaries.
@@ -183,8 +182,6 @@ jobs:
           echo "short=${sha:0:12}" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # rustc 1.95.0
-        with:
-          toolchain: 1.95.0
 
       # No build cache: cached objects must not feed shipped binaries.
       - name: Build node + cli


### PR DESCRIPTION
Fuzz was pinning the 1.95.0 rust-toolchain action SHA while passing toolchain: nightly (ignored; unexpected-input annotation). Use the nightly action tip for fuzz. Bump actions/cache to v5.1.0 and upload-artifact to v7.0.1 (Node 24). Drop redundant toolchain: 1.95.0 under the 1.95.0 SHA pin in ci/release.