### PR TITLE
ci: GitHub Release notes from scripts/release-notes.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,15 +251,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          notes="rbitcoin ${tag}
-
-          Linux **musl x86_64** is the operator binary (statically linked).
-          Windows is CRT-static PE (no IoRing). Darwin aarch64 is ad-hoc
-          codesigned, **not notarized** (\`xattr -d com.apple.quarantine\`).
-
-          Schema is still 0.x (refuse/wipe on incompatible open). Default
-          mainnet \`--milestone 840000\` skips historical scripts.
-          "
+          notes="$(./scripts/release-notes.sh "${tag#v}")"
           gh release create "$tag" \
             --repo "${{ github.repository }}" \
             --title "rbitcoin ${tag}" \


### PR DESCRIPTION
Stop hardcoding the platform blurb and stale 0.x/milestone text. The Release body is Highlights plus the install lines, matching the annotated tag.