### PR TITLE
docs: explain low-priority service policy

### DIFF
--- a/OPERATOR.md
+++ b/OPERATOR.md
@@ -79,6 +79,131 @@ Use the store-native glibc build instead when wanted:
 This selects the glibc build from rbitcoin's pinned `nixpkgs`; it does not
 rebuild the package against the NixOS system's `nixpkgs`.
 
+### Low-priority service on a shared Linux host
+
+Initial block download (IBD) sustains CPU and storage work for a long time. On
+a workstation or multipurpose server, running the service at low priority can
+keep interactive work and latency-sensitive services responsive while letting
+rbitcoin use otherwise-idle resources. This is an opt-in host policy, not a
+performance setting: sync can slow substantially under contention, and an idle
+I/O class can starve while higher-priority storage work continues.
+
+For a regular systemd installation, create a service drop-in with
+`systemctl edit rbitcoin.service`:
+
+```ini
+[Service]
+Nice=19
+CPUWeight=10
+IOWeight=10
+IOSchedulingClass=idle
+```
+
+Apply it at a planned service restart. The equivalent NixOS override composes
+with the shipped module:
+
+```nix
+{
+  systemd.services.rbitcoin.serviceConfig = {
+    Nice = 19;
+    CPUWeight = 10;
+    IOWeight = 10;
+    IOSchedulingClass = "idle";
+  };
+}
+```
+
+These controls cover different layers:
+
+- `Nice=19` lowers CPU scheduling priority for every rbitcoin thread.
+- `CPUWeight=10` requests a smaller relative CPU share than sibling cgroups
+  with the default weight of 100 through the cgroup v2 CPU controller and the
+  standard fair scheduler.
+- `IOSchedulingClass=idle` requests the kernel's idle per-process I/O class.
+- `IOWeight=10` gives the service a smaller relative share through the cgroup
+  v2 I/O controller.
+
+Weights divide resources only when eligible cgroups compete; they are not
+bandwidth caps. On an otherwise idle host, these settings still allow rbitcoin
+to use the available CPU and storage. They do not limit process memory or
+network traffic. Add memory limits only from a separate, host-specific capacity
+plan; an undersized limit can terminate the node or make IBD impractically slow.
+
+I/O priority is also storage-stack dependent. Linux currently implements
+per-process I/O priorities in the `bfq` and `mq-deadline` schedulers; `none`
+does not make `IOSchedulingClass=idle` effective. `mq-deadline` honors that
+process class but does not implement cgroup weights. `IOWeight` needs BFQ group
+scheduling or a configured kernel I/O cost controller; accepting the systemd
+setting alone does not prove that the storage stack enforces it. rbitcoin uses
+multiple OS threads and bulk `io_uring` or positional I/O, but systemd places
+all service tasks in the same cgroup; the kernel and active device scheduler
+still decide how strongly these requests are separated from other workloads.
+
+#### Select the block-device I/O scheduler
+
+Identify every physical device that backs `dataDir` and `coldDataDir`; layered
+storage such as LVM, RAID, dm-crypt, or multi-device filesystems may involve
+more than the mount's immediate block device:
+
+```bash
+findmnt -no SOURCE --target /var/lib/rbitcoin-mainnet
+lsblk -o NAME,TYPE,PKNAME,MOUNTPOINTS
+cat /sys/block/nvme0n1/queue/scheduler
+```
+
+The active scheduler appears in brackets, for example:
+
+```text
+none [mq-deadline] kyber
+```
+
+When the goal is to honor the idle I/O class, `mq-deadline` is a conservative
+choice when the device offers it. BFQ also implements process priorities and
+cgroup weights, and may improve latency isolation, but its fairness machinery
+can reduce throughput or add overhead on fast devices. Do not prescribe BFQ
+solely because a device is rotational or NVMe; test the tradeoff on the actual
+host. If maximum throughput matters more than isolation, leaving `none` active
+may be correct even though process I/O priority will not apply.
+
+Test a supported scheduler until reboot:
+
+```bash
+echo mq-deadline | sudo tee /sys/block/nvme0n1/queue/scheduler
+```
+
+The scheduler is device-wide, so this changes policy for every workload using
+that device, not only rbitcoin. Persist it only after verifying the physical
+device and available scheduler. A udev rule should match a stable device
+identity rather than a probe-order name:
+
+```udev
+ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", \
+  ENV{ID_WWN}=="<device-WWN>", ATTR{queue/scheduler}="mq-deadline"
+```
+
+Check the property first with
+`udevadm info --query=property --name=/dev/nvme0n1`; use another stable property
+such as `ID_SERIAL` if the device exports no `ID_WWN`. NixOS can persist the
+same exact-device rule:
+
+```nix
+{
+  services.udev.extraRules = ''
+    ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{ID_WWN}=="<device-WWN>", ATTR{queue/scheduler}="mq-deadline"
+  '';
+}
+```
+
+Re-check `/sys/block/<device>/queue/scheduler` after reboot. See the kernel
+documentation for [block I/O priorities](https://docs.kernel.org/block/ioprio.html),
+[BFQ](https://docs.kernel.org/block/bfq-iosched.html), and
+[switching schedulers](https://kernel.org/doc/html/latest/block/switching-sched.html),
+plus systemd's
+[`systemd.exec`](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html)
+and
+[`systemd.resource-control`](https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html)
+manuals for the enforcement boundaries.
+
 RPC, Electrum, and Esplora listeners are disabled by default. Their module
 options bind to loopback unless changed. Enabling Electrum or Esplora also
 enables the required scripthash index. `p2p.openFirewall`,

--- a/OPERATOR.md
+++ b/OPERATOR.md
@@ -79,6 +79,95 @@ Use the store-native glibc build instead when wanted:
 This selects the glibc build from rbitcoin's pinned `nixpkgs`; it does not
 rebuild the package against the NixOS system's `nixpkgs`.
 
+RPC, Electrum, and Esplora listeners are disabled by default. Their module
+options bind to loopback unless changed. Enabling Electrum or Esplora also
+enables the required scripthash index. `p2p.openFirewall`,
+`electrum.openFirewall`, and `esplora.openFirewall` are separate opt-ins.
+JSON-RPC has no firewall option; expose it only through an explicitly managed
+firewall or tunnel.
+
+The daemon does not terminate TLS. Keep its application listeners on loopback
+and compose them with a proxy. This example serves Esplora and RPC over HTTPS,
+and Electrum as TLS-wrapped TCP on port 50002, using one ACME certificate:
+
+```nix
+{
+  services.rbitcoin = {
+    rpc.enable = true;
+    electrum.enable = true;
+    esplora.enable = true;
+  };
+
+  security.acme = {
+    acceptTerms = true;
+    defaults.email = "operator@example.com";
+  };
+
+  services.nginx = {
+    enable = true;
+    recommendedProxySettings = true;
+    virtualHosts."node.example.com" = {
+      enableACME = true;
+      forceSSL = true;
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:3000";
+        proxyWebsockets = true;
+      };
+      locations."/rpc/".proxyPass = "http://127.0.0.1:8332/";
+    };
+    streamConfig = ''
+      server {
+        listen 50002 ssl;
+        proxy_pass 127.0.0.1:50001;
+        ssl_certificate /var/lib/acme/node.example.com/fullchain.pem;
+        ssl_certificate_key /var/lib/acme/node.example.com/key.pem;
+      }
+    '';
+  };
+
+  networking.firewall.allowedTCPPorts = [ 80 443 50002 ];
+}
+```
+
+Replace the hostname and email, then apply authentication and network policy to
+RPC for your deployment. nginx `virtualHosts` proxy HTTP; `streamConfig`
+proxies the Electrum TCP protocol.
+
+Use `coldDataDir` to place the large `inwit` store on another volume. The
+service creates the directory but does not mount or size the volume. Use
+`environment` for documented advanced `RBITCOIN_*` settings and `extraArgs`
+for daemon flags not represented by module options.
+
+**GitHub Release** (`v*.*.*` tags) is the operator snapshot: Linux musl +
+Windows CRT-static PE + Darwin aarch64 binaries + SHA256SUMS. Cut, merge,
+tag, and `vX.Y.x` / `.99` follow-up: [`docs/releases.md`](./docs/releases.md).
+
+```bash
+./scripts/release-post.sh --dry-run   # after the ship version is on the branch
+./scripts/release.sh --dry-run
+```
+
+Retry from Actions → **release** → Run workflow (artifacts only, no tag).
+PR `ci` **windows** / **macos** jobs smoke store create/open + `--smoke`;
+they do not upload binaries. Local Linux `target/release/` install is still
+`nix build .#rbitcoin-musl` on a clean master tree. Windows IoRing is not
+supported. Darwin/Windows are not Nix packages — see
+[`docs/reproducible-builds.md`](docs/reproducible-builds.md).
+
+**Darwin Gatekeeper:** the Darwin binaries are ad-hoc signed (`codesign -s -`), not
+notarized. If Finder or a browser sets quarantine and the binary is killed
+on launch:
+
+```bash
+xattr -d com.apple.quarantine rbitcoin-node rbitcoin-cli
+```
+
+**Windows store files** are opened `FILE_FLAG_OVERLAPPED` (IOCP). Header
+create/open/grow use positional `ReadFile`/`WriteFile` +
+`SetFileInformationByHandle`, not std `Read`/`Write`/`Seek`. Mixed
+Default `--datadir` is cwd-relative `datadir` via `Path::new(".").join("datadir")`
+(`./datadir` on Unix, `.\datadir` on Windows).
+
 ### Low-priority service on a shared Linux host
 
 Initial block download (IBD) sustains CPU and storage work for a long time. On
@@ -202,96 +291,8 @@ plus systemd's
 [`systemd.exec`](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html)
 and
 [`systemd.resource-control`](https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html)
-manuals for the enforcement boundaries.
-
-RPC, Electrum, and Esplora listeners are disabled by default. Their module
-options bind to loopback unless changed. Enabling Electrum or Esplora also
-enables the required scripthash index. `p2p.openFirewall`,
-`electrum.openFirewall`, and `esplora.openFirewall` are separate opt-ins.
-JSON-RPC has no firewall option; expose it only through an explicitly managed
-firewall or tunnel.
-
-The daemon does not terminate TLS. Keep its application listeners on loopback
-and compose them with a proxy. This example serves Esplora and RPC over HTTPS,
-and Electrum as TLS-wrapped TCP on port 50002, using one ACME certificate:
-
-```nix
-{
-  services.rbitcoin = {
-    rpc.enable = true;
-    electrum.enable = true;
-    esplora.enable = true;
-  };
-
-  security.acme = {
-    acceptTerms = true;
-    defaults.email = "operator@example.com";
-  };
-
-  services.nginx = {
-    enable = true;
-    recommendedProxySettings = true;
-    virtualHosts."node.example.com" = {
-      enableACME = true;
-      forceSSL = true;
-      locations."/" = {
-        proxyPass = "http://127.0.0.1:3000";
-        proxyWebsockets = true;
-      };
-      locations."/rpc/".proxyPass = "http://127.0.0.1:8332/";
-    };
-    streamConfig = ''
-      server {
-        listen 50002 ssl;
-        proxy_pass 127.0.0.1:50001;
-        ssl_certificate /var/lib/acme/node.example.com/fullchain.pem;
-        ssl_certificate_key /var/lib/acme/node.example.com/key.pem;
-      }
-    '';
-  };
-
-  networking.firewall.allowedTCPPorts = [ 80 443 50002 ];
-}
-```
-
-Replace the hostname and email, then apply authentication and network policy to
-RPC for your deployment. nginx `virtualHosts` proxy HTTP; `streamConfig`
-proxies the Electrum TCP protocol.
-
-Use `coldDataDir` to place the large `inwit` store on another volume. The
-service creates the directory but does not mount or size the volume. Use
-`environment` for documented advanced `RBITCOIN_*` settings and `extraArgs`
-for daemon flags not represented by module options.
-
-**GitHub Release** (`v*.*.*` tags) is the operator snapshot: Linux musl +
-Windows CRT-static PE + Darwin aarch64 binaries + SHA256SUMS. Cut, merge,
-tag, and `vX.Y.x` / `.99` follow-up: [`docs/releases.md`](./docs/releases.md).
-
-```bash
-./scripts/release-post.sh --dry-run   # after the ship version is on the branch
-./scripts/release.sh --dry-run
-```
-
-Retry from Actions → **release** → Run workflow (artifacts only, no tag).
-PR `ci` **windows** / **macos** jobs smoke store create/open + `--smoke`;
-they do not upload binaries. Local Linux `target/release/` install is still
-`nix build .#rbitcoin-musl` on a clean master tree. Windows IoRing is not
-supported. Darwin/Windows are not Nix packages — see
-[`docs/reproducible-builds.md`](docs/reproducible-builds.md).
-
-**Darwin Gatekeeper:** the Darwin binaries are ad-hoc signed (`codesign -s -`), not
-notarized. If Finder or a browser sets quarantine and the binary is killed
-on launch:
-
-```bash
-xattr -d com.apple.quarantine rbitcoin-node rbitcoin-cli
-```
-
-**Windows store files** are opened `FILE_FLAG_OVERLAPPED` (IOCP). Header
-create/open/grow use positional `ReadFile`/`WriteFile` +
-`SetFileInformationByHandle`, not std `Read`/`Write`/`Seek`. Mixed
-Default `--datadir` is cwd-relative `datadir` via `Path::new(".").join("datadir")`
-(`./datadir` on Unix, `.\datadir` on Windows).
+manuals for the enforcement boundaries. The shipped `nixosModules` unit does
+not apply these settings.
 
 ## First hour (regtest)
 


### PR DESCRIPTION
*Posted by Tau*

### Summary

Initial block download can sustain CPU and storage pressure on a shared host, but operators previously had no example for reducing its scheduling priority. This documents an opt-in systemd policy, its NixOS equivalent, and the corresponding block-device scheduler choices. The policy favors responsiveness under contention without imposing idle-host caps or promising faster syncs.

### Details

The guide separates nice levels, CPU and I/O cgroup weights, and the per-process idle I/O class. It explains their kernel and scheduler support boundaries, including that mq-deadline honors process I/O priority but not cgroup weights, while IOWeight needs BFQ group scheduling or configured iocost.

It also shows how to identify each physical backing device, test an available scheduler, and persist an exact-device udev rule. Device selection remains operator-owned because layered storage and device-wide scheduler effects cannot be inferred safely by the rbitcoin service module. Memory limits remain a separate host-specific capacity decision.

### Review

Independent review passed after clarifying CPUWeight and IOWeight enforcement boundaries. Re-review found no blockers or further issues.

### Verification

Reviewers can validate the examples with `systemd-analyze verify`, `nix-instantiate --parse`, and `udevadm verify`. The change is documentation-only; it does not alter service defaults or shipped code.